### PR TITLE
Categorical and Quantitative Filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ bifrost_jupyter_extension/labextension
 
 # eslint
 .eslintcache
+
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.pythonPath": "/Users/johnwaidhofer/miniconda3/envs/jupyter/bin/python"
+    "python.pythonPath": "/Users/johnwaidhofer/miniconda3/envs/bifrost_jupyter_extension-dev/bin/python"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/johnwaidhofer/miniconda3/envs/bifrost_jupyter_extension-dev/bin/python"
-}

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -131,6 +131,7 @@ class BifrostWidget(DOMWidget):
             "encodings": [
                 {"field": col, "type": types[col], "channel" : "?"} for col in df.columns
             ],
+            "transform": [],
             "chooseBy": "effectiveness"
         }
 

--- a/css/widget.css
+++ b/css/widget.css
@@ -1,6 +1,9 @@
-.custom-widget {
-  background-color: lightseagreen;
-  padding: 0px 2px;
+.bifrost-widget {
+  position: relative;
+  box-sizing: border-box;
+  border: 2px solid black;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 button.wrapper {

--- a/css/widget.css
+++ b/css/widget.css
@@ -1,9 +1,7 @@
 .bifrost-widget {
   position: relative;
   box-sizing: border-box;
-  border: 2px solid black;
   max-width: 100%;
-  overflow: hidden;
 }
 
 button.wrapper {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,13 +38,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "73aa23c7ab4e4855bd031a1a3cfff339",
+       "model_id": "52dd7108341a4430aec8229439c4f60e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,29 +20,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
     "cols = [\"foo\",\"y\", \"bar\", \"baz\", \"something\", \"else\"]\n",
     "dist = np.random.uniform(0,1, size=(1000,len(cols)))\n",
-    "df = pd.DataFrame(dist, columns=cols)"
+    "scatter_df = pd.DataFrame(dist, columns=cols)\n",
+    "\n",
+    "bar_df = pd.DataFrame([\n",
+    "    [\"John\", \"Developer\", 1],\n",
+    "    [\"Jay\", \"Developer\", 2],\n",
+    "    [\"Angela\", \"Designer\", 1],\n",
+    "    [\"Brian\", \"Leader\", 20]\n",
+    "], columns=[\"Name\", \"Job\", \"Years Worked For Jupyter\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3d09352afec2418cb53b018bb8fa0726",
+       "model_id": "73aa23c7ab4e4855bd031a1a3cfff339",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "BifrostWidget(df_columns=['foo', 'y', 'bar', 'baz', 'something', 'else'], graph_data=[{'foo': 0.4957819462, 'y…"
+       "BifrostWidget(df_columns=['Name', 'Job', 'Years Worked For Jupyter'], graph_data=[{'Name': 'John', 'Job': 'Dev…"
       ]
      },
      "metadata": {},
@@ -50,7 +57,7 @@
     }
    ],
    "source": [
-    "res = df.bifrost.plot()"
+    "res = bar_df.bifrost.plot()"
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,24 +9,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'BifrostWidget' from partially initialized module 'bifrost_jupyter_extension.bifrost' (most likely due to a circular import) (/Users/jaewookahn/projects/jupyter_widget/Jupyter-Bifrost/bifrost_jupyter_extension/bifrost.py)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-22b19c3fa4e9>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mbifrost_jupyter_extension\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbifrost\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpandas\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/projects/jupyter_widget/Jupyter-Bifrost/bifrost_jupyter_extension/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# Distributed under the terms of the Modified BSD License.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0mbifrost\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mBifrostWidget\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0m_version\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0m__version__\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mversion_info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/projects/jupyter_widget/Jupyter-Bifrost/bifrost_jupyter_extension/bifrost.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m\u001b[0m_frontend\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmodule_name\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodule_version\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mIPython\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdisplay\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mJSON\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mbifrost_jupyter_extension\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbifrost_accessor\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     20\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/projects/jupyter_widget/Jupyter-Bifrost/bifrost_jupyter_extension/bifrost_accessor/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mtyping\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpandas\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mbifrost_jupyter_extension\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbifrost\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mBifrostWidget\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mIPython\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdisplay\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mImportError\u001b[0m: cannot import name 'BifrostWidget' from partially initialized module 'bifrost_jupyter_extension.bifrost' (most likely due to a circular import) (/Users/jaewookahn/projects/jupyter_widget/Jupyter-Bifrost/bifrost_jupyter_extension/bifrost.py)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import bifrost_jupyter_extension\n",
     "import pandas as pd\n",
@@ -35,28 +20,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dist = np.random.uniform(0,1, size=(30,4))\n",
-    "df = pd.DataFrame(dist, columns=[\"foo\",\"y\", \"bar\", \"baz\"])"
+    "cols = [\"foo\",\"y\", \"bar\", \"baz\", \"something\", \"else\"]\n",
+    "dist = np.random.uniform(0,1, size=(1000,len(cols)))\n",
+    "df = pd.DataFrame(dist, columns=cols)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8fca88d12f0b42f3b34dbbaa45889773",
+       "model_id": "3d09352afec2418cb53b018bb8fa0726",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "BifrostWidget(df_columns=['foo', 'y', 'bar', 'baz'], graph_data=[{'foo': 0.8803420597, 'y': 0.9951287832, 'bar…"
+       "BifrostWidget(df_columns=['foo', 'y', 'bar', 'baz', 'something', 'else'], graph_data=[{'foo': 0.4957819462, 'y…"
       ]
      },
      "metadata": {},

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -4,16 +4,11 @@ import { jsx, css, ThemeProvider, Global } from '@emotion/react';
 // import Graph from './Graph';
 import Sidebar from './Sidebar/Sidebar';
 import { WidgetModel } from '@jupyter-widgets/base';
-import {
-  BifrostModelContext,
-  GraphSpec,
-  useModelState,
-} from '../hooks/bifrost-model';
-import React, { useEffect, useState, useRef } from 'react';
+import { BifrostModelContext } from '../hooks/bifrost-model';
+import React, { useState } from 'react';
 import ChartChooser from './Onboarding/ChartChooser';
 import ColumnScreen from './Onboarding/ColumnScreen';
 import { VisualizationSpec } from 'react-vega';
-import produce from 'immer';
 import Graph from './Graph';
 import theme from '../theme';
 
@@ -113,24 +108,9 @@ function VisualizationScreen({
   spec: VisualizationSpec;
   onPrevious: () => void;
 }) {
-  const [graphSpec, setGraphSpec] = useModelState<GraphSpec>('graph_spec');
-  const graphAreaRef = useRef<HTMLDivElement>(null);
-  useResize(
-    (e) => {
-      if (!graphAreaRef.current) return;
-      const { width, height } = graphAreaRef.current.getBoundingClientRect();
-      const newSpec = produce(graphSpec, (gs) => {
-        gs.width = width;
-        gs.height = height;
-      });
-      setGraphSpec(newSpec);
-    },
-    [graphAreaRef.current]
-  );
-
   return (
     <article className="BifrostWidget" css={bifrostWidgetCss}>
-      <GridArea ref={graphAreaRef} area="graph">
+      <GridArea area="graph">
         <Graph onBack={onPrevious} />
       </GridArea>
       <GridArea area="sidebar">
@@ -152,10 +132,3 @@ const GridArea = React.forwardRef<HTMLDivElement, GridAreaProps>(
     </div>
   )
 );
-
-function useResize(callback: (e: UIEvent) => void, deps: any[]) {
-  useEffect(() => {
-    window.addEventListener('resize', callback);
-    return () => void window.removeEventListener('resize', callback);
-  }, deps);
-}

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -4,8 +4,8 @@ import { jsx, css, ThemeProvider, Global } from '@emotion/react';
 // import Graph from './Graph';
 import Sidebar from './Sidebar/Sidebar';
 import { WidgetModel } from '@jupyter-widgets/base';
-import { BifrostModelContext } from '../hooks/bifrost-model';
-import { useState } from 'react';
+import { BifrostModelContext, useModelState } from '../hooks/bifrost-model';
+import { useEffect, useState, useRef } from 'react';
 import ChartChooser from './Onboarding/ChartChooser';
 import ColumnScreen from './Onboarding/ColumnScreen';
 import { VisualizationSpec } from 'react-vega';
@@ -108,9 +108,18 @@ function VisualizationScreen({
   spec: VisualizationSpec;
   onPrevious: () => void;
 }) {
+  const setGraphSpec = useModelState('graph_spec')[1];
+  const graphAreaRef = useRef<HTMLDivElement>();
+  useResize(
+    (e) => {
+      graphAreaRef.current?.getBoundingClientRect;
+    },
+    [graphAreaRef.current]
+  );
+
   return (
     <article className="BifrostWidget" css={bifrostWidgetCss}>
-      <GridArea area="graph">
+      <GridArea ref={graphAreaRef} area="graph">
         <Graph onBack={onPrevious} />
       </GridArea>
       <GridArea area="sidebar">
@@ -120,6 +129,23 @@ function VisualizationScreen({
   );
 }
 
-function GridArea(props: { area: string; children: any }) {
-  return <div style={{ gridArea: props.area }}>{props.children}</div>;
+interface GridAreaProps {
+  area: string;
+  children?: any;
+  ref?: React.LegacyRef<HTMLDivElement>;
+}
+
+function GridArea(props: GridAreaProps) {
+  return (
+    <div style={{ gridArea: props.area }} ref={props.ref}>
+      {props.children}
+    </div>
+  );
+}
+
+function useResize(callback: (e: UIEvent) => void, deps: any[]) {
+  useEffect(() => {
+    window.addEventListener('resize', callback);
+    return () => void window.removeEventListener('resize', callback);
+  }, deps);
 }

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx, css, ThemeProvider } from '@emotion/react';
+import { jsx, css, ThemeProvider, Global } from '@emotion/react';
 
 // import Graph from './Graph';
 import Sidebar from './Sidebar/Sidebar';
@@ -18,7 +18,10 @@ const bifrostWidgetCss = css`
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-template-areas: 'graph sidebar';
+  max-width: calc(100% - 64px);
+`;
 
+const globalStyles = css`
   // Global styles for the widget
   //===========================================================
   * {
@@ -32,6 +35,18 @@ const bifrostWidgetCss = css`
     &:active {
       transform: scale(0.95);
     }
+  }
+
+  h1 {
+    font-size: 35px;
+    font-weight: 800;
+    margin: 10px 0;
+    margin-bottom: 15px;
+  }
+
+  h2 {
+    font-size: 25px;
+    font-weight: 800;
   }
 `;
 
@@ -80,6 +95,7 @@ export default function BifrostReactWidget(props: BifrostReactWidgetProps) {
     <ThemeProvider theme={theme}>
       <BifrostModelContext.Provider value={props.model}>
         {Screen}
+        <Global styles={globalStyles} />
       </BifrostModelContext.Provider>
     </ThemeProvider>
   );

--- a/src/components/Onboarding/ChartChooser.tsx
+++ b/src/components/Onboarding/ChartChooser.tsx
@@ -1,10 +1,9 @@
 /** @jsx jsx */
 import { jsx, css } from '@emotion/react';
 import { useState } from 'react';
-import { VegaLite, VisualizationSpec } from 'react-vega';
+import { PlainObject, VegaLite, VisualizationSpec } from 'react-vega';
 import {
   useModelState,
-  GraphData,
   SuggestedGraphs,
   GraphSpec,
 } from '../../hooks/bifrost-model';
@@ -31,7 +30,9 @@ interface ChartChooserProps {
 
 export default function ChartChooser(props: ChartChooserProps) {
   const suggestedGraphs = useModelState<SuggestedGraphs>('suggested_graphs')[0];
-  const data = useModelState<GraphData>('graph_data', (data) => ({ data }))[0];
+  const data = useModelState<PlainObject>('graph_data', (data) => ({
+    data,
+  }))[0];
   const setGraphSpec = useModelState<GraphSpec>('graph_spec')[1];
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
 

--- a/src/components/Onboarding/NavHeader.tsx
+++ b/src/components/Onboarding/NavHeader.tsx
@@ -63,8 +63,8 @@ const nextButtonCss = css`
   border: none;
   border-radius: 50%;
   cursor: pointer;
-  width: 35px;
-  height: 35px;
+  width: 55px;
+  height: 55px;
   margin-left: 20px;
 `;
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -8,6 +8,12 @@ import CustomizationTab from './Tabs/CustomizationTab';
 const sidebarCss = css`
   width: 100%;
   height: 100%;
+
+  .sidebar-content {
+    border: 2px solid #e4e4e4;
+    border-top: none;
+    padding: 10px;
+  }
 `;
 const tabMapping: { [name: string]: () => jsx.JSX.Element } = {
   Variables: VariablesTab,
@@ -26,7 +32,7 @@ export default function Sidebar() {
         onTabSelected={setSelectedTab}
         activeTab={selectedTab}
       />
-      <div className="content">
+      <div className="sidebar-content">
         <TabContents />
       </div>
     </aside>

--- a/src/components/Sidebar/Tabs/FilterScreen.tsx
+++ b/src/components/Sidebar/Tabs/FilterScreen.tsx
@@ -1,0 +1,152 @@
+/**@jsx jsx */
+import { jsx, css } from '@emotion/react';
+import produce from 'immer';
+import { useMemo } from 'react';
+import { ArrowLeft } from 'react-feather';
+import { GraphSpec, useModelState } from '../../../hooks/bifrost-model';
+import { VegaEncoding } from '../../../modules/VegaEncodings';
+
+const screenCss = (theme: any) => css`
+  position: absolute;
+  top: 0;
+  background-color: ${theme.color.background[0]};
+  width: 100%;
+  height: 100%;
+  overflow-y: scroll;
+
+  h1 {
+    .encoding {
+      color: ${theme.color.primary};
+    }
+  }
+`;
+
+interface FilterGroupProps {
+  encoding: VegaEncoding;
+}
+
+const filterMap: {
+  [type: string]: (props: FilterGroupProps) => jsx.JSX.Element;
+} = {
+  quantitative: QuantitativeFilters,
+  nominal: CategoricalFilters,
+};
+
+interface FilterScreenProps {
+  encoding: VegaEncoding;
+  onBack(): void;
+}
+
+export default function FilterScreen(props: FilterScreenProps) {
+  const [graphSpec] = useModelState<GraphSpec>('graph_spec');
+  const columnInfo = graphSpec.encoding[props.encoding];
+  const Filters = filterMap[columnInfo.type];
+
+  return (
+    <article css={screenCss}>
+      <button className="wrapper" onClick={props.onBack}>
+        <ArrowLeft />
+      </button>
+      <h1>
+        <span className="encoding">{props.encoding}</span>{' '}
+        <span className="column">{columnInfo.field}</span>
+      </h1>
+      <Filters encoding={props.encoding} />
+    </article>
+  );
+}
+
+type GraphData<T> = { [col: string]: T }[];
+
+function QuantitativeFilters(props: FilterGroupProps) {
+  const [graphData] = useModelState<GraphData<number>>('graph_data');
+  const [graphSpec, setGraphSpec] = useModelState<GraphSpec>('graph_spec');
+  const { field } = graphSpec.encoding[props.encoding];
+  const bounds: [number, number] = useMemo(
+    () =>
+      graphData.reduce(
+        (minMax, cur) => {
+          let val = cur[field];
+          if (minMax[0] > val) minMax[0] = val;
+          if (minMax[1] < val) minMax[1] = val;
+          return minMax;
+        },
+        [Infinity, -Infinity]
+      ),
+    [graphData]
+  );
+
+  function updateFilter(type: string, val: number) {
+    const index = graphSpec.transform.findIndex(
+      (t) => t.filter.field === field && type in t.filter
+    );
+    let newSpec: GraphSpec;
+    if (index !== -1) {
+      // Filter exists
+      newSpec = produce(graphSpec, (gs) => {
+        gs.transform[index].filter[type] = val;
+      });
+    } else {
+      // Create Filter
+      newSpec = produce(graphSpec, (gs) => {
+        gs.transform.push({
+          filter: {
+            field,
+            [type]: val,
+          },
+        });
+      });
+    }
+    setGraphSpec(newSpec);
+    console.log(newSpec.transform);
+  }
+
+  function getFilterVal(type: string): number | undefined {
+    return graphSpec.transform.find(
+      (f) => f.filter.field === field && type in f.filter
+    )?.filter[type];
+  }
+
+  const currentMin = getFilterVal('gte');
+  const currentMax = getFilterVal('lte');
+
+  return (
+    <div className="filters">
+      <label>
+        Min
+        <input
+          type="range"
+          value={currentMin}
+          min={bounds[0]}
+          max={bounds[1]}
+          step={(bounds[1] - bounds[0]) / 100}
+          onChange={(e) => updateFilter('gte', e.target.valueAsNumber)}
+        />
+      </label>
+
+      <label>
+        Max:
+        <input
+          type="range"
+          value={currentMax}
+          min={bounds[0]}
+          max={bounds[1]}
+          step={(bounds[1] - bounds[0]) / 100}
+          onChange={(e) => updateFilter('lte', e.target.valueAsNumber)}
+        />
+      </label>
+    </div>
+  );
+}
+
+function CategoricalFilters(props: FilterGroupProps) {
+  const [graphData] = useModelState<GraphData<string>>('graph_data');
+
+  return (
+    <ul>
+      {Object.keys(graphData[0]).map((k) => (
+        <li key={k}>{k}</li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/Sidebar/Tabs/VariablesTab.tsx
+++ b/src/components/Sidebar/Tabs/VariablesTab.tsx
@@ -12,8 +12,10 @@ import {
 import { VegaEncoding, vegaEncodingList } from '../../../modules/VegaEncodings';
 import Pill from '../../ui-widgets/Pill';
 import SearchBar from '../../ui-widgets/SearchBar';
+import FilterScreen from './FilterScreen';
 
 const variableTabCss = css`
+  position: relative;
   .encoding-list,
   .encoding-choices {
     margin: 0;
@@ -46,6 +48,7 @@ export default function VariablesTab() {
   const [graphSpec, setGraphSpec] = useModelState<GraphSpec>('graph_spec');
   const [activeEncoding, setActiveEncoding] = useState<VegaEncoding | ''>('');
   const [showEncodings, setShowEncodings] = useState(false);
+  const [filterEncoding, setFilterEncoding] = useState<VegaEncoding | ''>('');
 
   const updateEncodings = (column: string) => {
     if (activeEncoding === '') {
@@ -78,8 +81,8 @@ export default function VariablesTab() {
     setGraphSpec(newSpec);
   }
 
-  function openFilters(encoding: string) {
-    console.log('open filters...');
+  function openFilters(encoding: VegaEncoding) {
+    setFilterEncoding(encoding);
   }
 
   function addEncoding(encoding: VegaEncoding) {
@@ -114,7 +117,10 @@ export default function VariablesTab() {
           <XCircle size={20} />
         </button>
         <b>{encoding}:</b> <span>{col.field}</span>
-        <button className="wrapper" onClick={() => openFilters(encoding)}>
+        <button
+          className="wrapper"
+          onClick={() => openFilters(encoding as VegaEncoding)}
+        >
           <Filter size={20} />
         </button>
       </Pill>
@@ -159,6 +165,12 @@ export default function VariablesTab() {
           );
         })}
       </ul>
+      {filterEncoding && (
+        <FilterScreen
+          encoding={filterEncoding}
+          onBack={() => setFilterEncoding('')}
+        />
+      )}
     </section>
   );
 }

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -4,7 +4,7 @@ import { PlainObject, VisualizationSpec } from 'react-vega';
 import { Query } from 'compassql/build/src/query/query';
 import { ResultTree } from 'compassql/build/src/result';
 import { TopLevel, FacetedUnitSpec } from 'vega-lite/build/src/spec';
-import { VegaEncoding } from '../modules/VegaEncodings';
+import { VegaColumnType, VegaEncoding } from '../modules/VegaEncodings';
 export const BifrostModelContext = createContext<WidgetModel | undefined>(
   undefined
 );
@@ -45,7 +45,11 @@ export type QuerySpec = Query;
 
 export interface EncodingInfo {
   field: string;
-  type: string;
+  type: VegaColumnType | "";
+  scale?: {
+    [scaleType: string] : any
+  },
+  
 }
 
 export type GraphSpec = VisualizationSpec & {
@@ -53,6 +57,9 @@ export type GraphSpec = VisualizationSpec & {
   height: number;
   mark: string;
   encoding: Record<VegaEncoding, EncodingInfo>;
+  transform: {
+    [transformType: string] : any
+  }[];
   data: { name: string };
 };
 

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -49,7 +49,7 @@ export interface EncodingInfo {
   scale?: {
     [scaleType: string] : any
   },
-  
+  aggregate?: string
 }
 
 export type GraphSpec = VisualizationSpec & {

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -45,11 +45,11 @@ export type QuerySpec = Query;
 
 export interface EncodingInfo {
   field: string;
-  type: VegaColumnType | "";
+  type: VegaColumnType | '';
   scale?: {
-    [scaleType: string] : any
-  },
-  aggregate?: string
+    [scaleType: string]: any;
+  };
+  aggregate?: string;
 }
 
 export type GraphSpec = VisualizationSpec & {
@@ -58,7 +58,7 @@ export type GraphSpec = VisualizationSpec & {
   mark: string;
   encoding: Record<VegaEncoding, EncodingInfo>;
   transform: {
-    [transformType: string] : any
+    [transformType: string]: any;
   }[];
   data: { name: string };
 };

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -57,39 +57,39 @@ export const vegaEncodingList = [
 ] as const;
 
 const vegaColTypesList = [
-  "quantitative",
-  "temporal",
-  "ordinal",
-  "nominal",
-  "geojson",
-] as const
+  'quantitative',
+  'temporal',
+  'ordinal',
+  'nominal',
+  'geojson',
+] as const;
 
 export const vegaAggregationList = [
-  "count",
-  "valid",
-  "values",
-  "missing",
-  "distinct",
-  "sum",
-  "product",
-  "mean",
-  "variance",
-  "variancep",
-  "stdev",
-  "stdevp",
-  "stderr",
-  "median",
-  "q1",
-  "q3",
-  "ci0",
-  "ci1",
-  "min",
-  "max",
-  "argmin",
-  "argmax"
-] as const
+  'count',
+  'valid',
+  'values',
+  'missing',
+  'distinct',
+  'sum',
+  'product',
+  'mean',
+  'variance',
+  'variancep',
+  'stdev',
+  'stdevp',
+  'stderr',
+  'median',
+  'q1',
+  'q3',
+  'ci0',
+  'ci1',
+  'min',
+  'max',
+  'argmin',
+  'argmax',
+] as const;
 
-export type VegaColumnType = typeof vegaColTypesList[number]
+export type VegaColumnType = typeof vegaColTypesList[number];
 
 export type VegaEncoding = typeof vegaEncodingList[number];
 

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -64,6 +64,33 @@ const vegaColTypesList = [
   "geojson",
 ] as const
 
+export const vegaAggregationList = [
+  "count",
+  "valid",
+  "values",
+  "missing",
+  "distinct",
+  "sum",
+  "product",
+  "mean",
+  "variance",
+  "variancep",
+  "stdev",
+  "stdevp",
+  "stderr",
+  "median",
+  "q1",
+  "q3",
+  "ci0",
+  "ci1",
+  "min",
+  "max",
+  "argmin",
+  "argmax"
+] as const
+
 export type VegaColumnType = typeof vegaColTypesList[number]
 
 export type VegaEncoding = typeof vegaEncodingList[number];
+
+export type VegaAggregation = typeof vegaAggregationList[number];

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -54,6 +54,16 @@ export const vegaEncodingList = [
   'facet',
   'row',
   'column',
-];
+] as const;
+
+const vegaColTypesList = [
+  "quantitative",
+  "temporal",
+  "ordinal",
+  "nominal",
+  "geojson",
+] as const
+
+export type VegaColumnType = typeof vegaColTypesList[number]
 
 export type VegaEncoding = typeof vegaEncodingList[number];

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,0 +1,2 @@
+export const isFunction = (val: any): val is Function =>
+  val && {}.toString.call(val) === '[object Function]';


### PR DESCRIPTION
Fixes #8 , fixes #10 
**Added Aggregators and Categorical Filters to the Variables Screen**

## Test
1. Choose a graph with one quantitative and one categorical variable (the `introduction` notebook has a new df with such variables).
2. Click on the filter for the quantitative variable. 
3. Verify that you can change the range showing by sliding the min and max sliders.
4. Verify that you can aggregate with the aggregation dropdown.
5. Click on the filter for the categorical variable.
6. Verify that you can toggle the categories in the categorical column. 