### PR TITLE
Code Export

### DIFF
--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -6,7 +6,7 @@
 import pandas as pd
 import random, typing
 
-from traitlets.traitlets import validate, observe
+from traitlets.traitlets import observe
 
 """
 TODO: Add module docstring

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -39,7 +39,7 @@ class BifrostWidget(DOMWidget):
     flags = Dict({}).tag(sync=True)
     graph_data = List([]).tag(sync=True)
     graph_encodings = Dict({}).tag(sync=True)
-    df_variable_name:str = "" 
+    df_variable_name:str = Unicode("").tag(sync=True)
     output_variable: str = ""
     generate_random_dist = Int(0).tag(sync=True)
     df_columns = List([]).tag(sync=True)

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -15,7 +15,8 @@
    "source": [
     "import bifrost_jupyter_extension\n",
     "import pandas as pd\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from sklearn.datasets import load_iris"
    ]
   },
   {
@@ -33,7 +34,10 @@
     "    [\"Jay\", \"Developer\", 2],\n",
     "    [\"Angela\", \"Designer\", 1],\n",
     "    [\"Brian\", \"Leader\", 20]\n",
-    "], columns=[\"Name\", \"Job\", \"Years Worked For Jupyter\"])"
+    "], columns=[\"Name\", \"Job\", \"Years Worked For Jupyter\"])\n",
+    "\n",
+    "iris_ds = load_iris()\n",
+    "iris_df = pd.DataFrame(iris_ds[\"data\"], columns=iris_ds[\"feature_names\"])"
    ]
   },
   {

--- a/src/components/Onboarding/ColumnScreen.tsx
+++ b/src/components/Onboarding/ColumnScreen.tsx
@@ -112,7 +112,9 @@ export default function ColumnScreen(props: ColumnScreenProps) {
   const data = useModelState<GraphData>('graph_data')[0];
   const setSuggestedGraphs =
     useModelState<SuggestedGraphs>('suggested_graphs')[1];
-  const [results, setResults] = useState(columnChoices);
+  const [results, setResults] = useState(
+    columnChoices.map((choice, index) => ({ choice, index }))
+  );
   const optionsRef = useRef<HTMLFieldSetElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -144,7 +146,6 @@ export default function ColumnScreen(props: ColumnScreenProps) {
       });
     }
 
-    console.log({ filteredSpecs });
     const items = filteredSpecs
       .map((spec) => recommend(spec, schema, opt).result)
       .map((res) =>
@@ -288,7 +289,7 @@ export default function ColumnScreen(props: ColumnScreenProps) {
         </NavHeader>
         <form onSubmit={(e) => e.preventDefault()}>
           <fieldset ref={optionsRef}>
-            {results.map((col, i) => {
+            {results.map(({ choice: col }, i) => {
               return (
                 <label
                   className={i === focusedIdx ? 'choice focused' : 'choice'}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -5,6 +5,7 @@ import VariablesTab from './Tabs/VariablesTab';
 import HistoryTab from './Tabs/HistoryTab';
 import CustomizationTab from './Tabs/CustomizationTab';
 import { useModelState, GraphSpec } from '../../hooks/bifrost-model';
+import VegaPandasTranslator from '../../modules/VegaPandasTranslator';
 
 const sidebarCss = css`
   width: 100%;
@@ -109,9 +110,14 @@ function ActionBar() {
   const [opHistory, setOpHistory] = useModelState<GraphSpec[]>('spec_history');
   const spec = useModelState<GraphSpec>('graph_spec')[0];
   const [index, setIndex] = useModelState<number>('current_dataframe_index');
+  const [dataframeName] = useModelState<string>('df_variable_name');
 
   function exportCode() {
-    alert("We'll have this done real soon!");
+    const translator = new VegaPandasTranslator();
+    const query = translator
+      .convertSpecToCode(spec)
+      .replace(/\$df/g, dataframeName || 'df');
+    navigator.clipboard.writeText(query);
   }
 
   function applyGraphChanges() {

--- a/src/components/Sidebar/Tabs/HistoryTab.tsx
+++ b/src/components/Sidebar/Tabs/HistoryTab.tsx
@@ -1,6 +1,6 @@
 /**@jsx jsx */
 import { jsx, css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMemo } from 'react';
 import { GraphSpec, useModelState } from '../../../hooks/bifrost-model';
 import SearchBar from '../../ui-widgets/SearchBar';
@@ -29,21 +29,49 @@ const historyCss = (theme: any) => css`
 `;
 
 export default function HistoryTab() {
-  const setSpec = useModelState<GraphSpec>('graph_spec')[1];
-  const specHistory = useModelState<GraphSpec[]>('spec_history')[0];
+  const [spec, setSpec] = useModelState<GraphSpec>('graph_spec');
+  const [specHistory, setSpecHistory] =
+    useModelState<GraphSpec[]>('spec_history');
   const [dfIndex, setDfIndex] = useModelState<number>(
     'current_dataframe_index'
   );
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setResults] = useState<string[]>([]);
-  const histDescriptions = useMemo(
-    () => generateDescriptions(specHistory),
+  const [searchResults, setResults] = useState<
+    { choice: string; index: number }[]
+  >([]);
+  const reverseHistory = useMemo(
+    () => [...specHistory].reverse(),
     [specHistory]
   );
+  const histDescriptions = useMemo(
+    () => generateDescriptions(reverseHistory),
+    [reverseHistory]
+  );
+
+  useEffect(function saveSpecOnMount() {
+    const updatedHist = specHistory.slice(0, dfIndex + 1);
+    updatedHist.push(spec);
+    setSpecHistory(updatedHist);
+    setDfIndex(updatedHist.length - 1);
+
+    return () => {
+      setSpecHistory(updatedHist.slice(0, updatedHist.length - 1));
+      if (dfIndex > updatedHist.length - 2) setDfIndex(updatedHist.length - 2);
+    };
+  }, []);
+
+  /**
+   * Preserves the spec state when the user navigates to the history tab
+   * and deletes the temporarily saved spec when the user navigates away.
+   */
+
+  function invertHistIndex(i: number) {
+    return specHistory.length - 1 - i;
+  }
 
   function setHistoryPosition(index: number) {
-    setDfIndex(index);
-    setSpec(specHistory[index]);
+    setDfIndex(invertHistIndex(index));
+    setSpec(reverseHistory[index]);
   }
 
   return (
@@ -54,7 +82,9 @@ export default function HistoryTab() {
         value={dfIndex}
         min={0}
         max={specHistory.length - 1}
-        onChange={(e) => setHistoryPosition(e.target.valueAsNumber)}
+        onChange={(e) =>
+          setHistoryPosition(invertHistIndex(e.target.valueAsNumber))
+        }
       />
 
       <SearchBar
@@ -64,14 +94,17 @@ export default function HistoryTab() {
         onResultsChange={setResults}
       />
       <ul className="history-list">
-        {searchResults.map((description, i) => {
+        {searchResults.map(({ choice, index }, elIndex) => {
           return (
             <li
-              className={'history-el' + (i === dfIndex ? ' active' : '')}
-              key={i}
-              onClick={() => setHistoryPosition(i)}
+              className={
+                'history-el' +
+                (index === invertHistIndex(dfIndex) ? ' active' : '')
+              }
+              key={index}
+              onClick={() => setHistoryPosition(index)}
             >
-              {description}
+              {choice}
             </li>
           );
         })}

--- a/src/components/Sidebar/Tabs/HistoryTab.tsx
+++ b/src/components/Sidebar/Tabs/HistoryTab.tsx
@@ -52,7 +52,7 @@ export default function HistoryTab() {
     [reverseHistory]
   );
 
-  useEffect(function saveSpecOnMount() {
+  useEffect(() => {
     const updatedHist = specHistory.slice(0, dfIndex + 1);
     updatedHist.push(spec);
     setSpecHistory(updatedHist);
@@ -60,7 +60,9 @@ export default function HistoryTab() {
 
     return () => {
       setSpecHistory(updatedHist.slice(0, updatedHist.length - 1));
-      if (dfIndex > updatedHist.length - 2) setDfIndex(updatedHist.length - 2);
+      if (dfIndex > updatedHist.length - 2) {
+        setDfIndex(updatedHist.length - 2);
+      }
     };
   }, []);
 

--- a/src/components/Sidebar/Tabs/HistoryTab.tsx
+++ b/src/components/Sidebar/Tabs/HistoryTab.tsx
@@ -24,6 +24,10 @@ const historyCss = (theme: any) => css`
         border-left: 3px solid ${theme.color.primary[1]};
         font-weight: 700;
       }
+
+      &.temporary {
+        color: gray;
+      }
     }
   }
 `;
@@ -95,16 +99,22 @@ export default function HistoryTab() {
       />
       <ul className="history-list">
         {searchResults.map(({ choice, index }, elIndex) => {
+          const classes = [
+            ['history-el', true],
+            ['active', index === invertHistIndex(dfIndex)],
+            ['temporary', index === 0],
+          ]
+            .filter((pair) => pair[1])
+            .map((pair) => pair[0])
+            .join(' ');
+
           return (
             <li
-              className={
-                'history-el' +
-                (index === invertHistIndex(dfIndex) ? ' active' : '')
-              }
+              className={classes}
               key={index}
               onClick={() => setHistoryPosition(index)}
             >
-              {choice}
+              {(index === 0 ? '(Unsaved) ' : '') + choice}
             </li>
           );
         })}

--- a/src/components/Sidebar/Tabs/VariablesTab.tsx
+++ b/src/components/Sidebar/Tabs/VariablesTab.tsx
@@ -20,6 +20,13 @@ const variableTabCss = css`
   .encoding-choices {
     margin: 0;
     padding: 0;
+
+    .encoding-wrapper {
+      display: flex;
+      b {
+        margin-right: 5px;
+      }
+    }
   }
 
   .encoding-choices {
@@ -116,7 +123,11 @@ export default function VariablesTab() {
         >
           <XCircle size={20} />
         </button>
-        <b>{encoding}:</b> <span>{col.field}</span>
+        <div className="encoding-wrapper">
+          <b>{encoding}:</b>
+          <span>{col.field}</span>
+        </div>
+
         <button
           className="wrapper"
           onClick={() => openFilters(encoding as VegaEncoding)}

--- a/src/components/Sidebar/Tabs/VariablesTab.tsx
+++ b/src/components/Sidebar/Tabs/VariablesTab.tsx
@@ -50,7 +50,9 @@ const variableTabCss = css`
 export default function VariablesTab() {
   const columns = useModelState<string[]>('df_columns')[0];
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState(columns);
+  const [searchResults, setSearchResults] = useState(
+    columns.map((choice, index) => ({ choice, index }))
+  );
   const querySpec = useModelState<QuerySpec>('query_spec')[0];
   const [graphSpec, setGraphSpec] = useModelState<GraphSpec>('graph_spec');
   const [activeEncoding, setActiveEncoding] = useState<VegaEncoding | ''>('');
@@ -164,7 +166,7 @@ export default function VariablesTab() {
         placeholder="Search Columns"
       />
       <ul className="columns-list">
-        {searchResults.map((col) => {
+        {searchResults.map(({ choice: col }) => {
           return (
             <li
               className="column-el"

--- a/src/components/ui-widgets/SearchBar.tsx
+++ b/src/components/ui-widgets/SearchBar.tsx
@@ -35,7 +35,7 @@ const searchIconCss = css`
 
 export interface SearchProps {
   choices: string[];
-  onResultsChange: (results: string[]) => void;
+  onResultsChange: (results: { choice: string; index: number }[]) => void;
   onChange: (value: string) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   value: string;
@@ -52,20 +52,26 @@ export default function SearchBar(props: SearchProps) {
         name.replace(notAlpha, '').toLowerCase(),
         normQuery
       )?.score;
+
+    const indexedChoices = props.choices.map((choice, index) => ({
+      choice,
+      index,
+    }));
     if (props.value.length === 0) {
-      props.onResultsChange(props.choices);
+      props.onResultsChange(indexedChoices);
     } else {
-      const results = props.choices.filter((name) => {
-        return compScore(name) === undefined ? false : true;
+      const results = indexedChoices.filter(({ choice }) => {
+        return compScore(choice) === undefined ? false : true;
       });
 
       // Ik the casting is bad but the filter above guarantees that these are numbers, so its valid practice.
       results.sort(
-        (a, b) => (compScore(a) as number) - (compScore(b) as number)
+        (a, b) =>
+          (compScore(a.choice) as number) - (compScore(b.choice) as number)
       );
       props.onResultsChange(results);
     }
-  }, [props.value]);
+  }, [props.value, props.choices]);
 
   return (
     <div className="searchBar" css={searchBarCss}>

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -64,37 +64,42 @@ const vegaColTypesList = [
   'geojson',
 ] as const;
 
-// 
+//
 export const vegaAggregationList = [
-// "argmax",
-// "argmin",
-// "ci0",
-// "ci1",
-"count",
-"distinct",
-"max",
-"mean",
-"median",
-"min",
- "missing",
- "product",
-//  "q1",
-//  "q3",
- "stderr",
- "stdev",
- "stdevp",
- "sum",
- "valid",
- "values",
- "variance",
- "variancep"
-
+  // "argmax",
+  // "argmin",
+  // "ci0",
+  // "ci1",
+  'count',
+  'distinct',
+  'max',
+  'mean',
+  'median',
+  'min',
+  'missing',
+  'product',
+  //  "q1",
+  //  "q3",
+  'stderr',
+  'stdev',
+  'stdevp',
+  'sum',
+  'valid',
+  'values',
+  'variance',
+  'variancep',
 ] as const;
 
-
-
-
-export const vegaParamPredicatesList = ["equal", "lt", "lte", "gt", "gte", "range", "oneOf", "valid"] as const;
+export const vegaParamPredicatesList = [
+  'equal',
+  'lt',
+  'lte',
+  'gt',
+  'gte',
+  'range',
+  'oneOf',
+  'valid',
+] as const;
 
 export type VegaColumnType = typeof vegaColTypesList[number];
 
@@ -102,4 +107,3 @@ export type VegaEncoding = typeof vegaEncodingList[number];
 
 export type VegaAggregation = typeof vegaAggregationList[number];
 export type VegaParamPredicate = typeof vegaParamPredicatesList[number];
-

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -64,30 +64,35 @@ const vegaColTypesList = [
   'geojson',
 ] as const;
 
+// 
 export const vegaAggregationList = [
-  'count',
-  'valid',
-  'values',
-  'missing',
-  'distinct',
-  'sum',
-  'product',
-  'mean',
-  'variance',
-  'variancep',
-  'stdev',
-  'stdevp',
-  'stderr',
-  'median',
-  'q1',
-  'q3',
-  'ci0',
-  'ci1',
-  'min',
-  'max',
-  'argmin',
-  'argmax',
+// "argmax",
+// "argmin",
+// "ci0",
+// "ci1",
+"count",
+"distinct",
+"max",
+"mean",
+"median",
+"min",
+ "missing",
+ "product",
+//  "q1",
+//  "q3",
+ "stderr",
+ "stdev",
+ "stdevp",
+ "sum",
+ "valid",
+ "values",
+ "variance",
+ "variancep"
+
 ] as const;
+
+
+
 
 export const vegaParamPredicatesList = ["equal", "lt", "lte", "gt", "gte", "range", "oneOf", "valid"] as const;
 

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -89,8 +89,12 @@ export const vegaAggregationList = [
   'argmax',
 ] as const;
 
+export const vegaParamPredicatesList = ["equal", "lt", "lte", "gt", "gte", "range", "oneOf", "valid"] as const;
+
 export type VegaColumnType = typeof vegaColTypesList[number];
 
 export type VegaEncoding = typeof vegaEncodingList[number];
 
 export type VegaAggregation = typeof vegaAggregationList[number];
+export type VegaParamPredicate = typeof vegaParamPredicatesList[number];
+

--- a/src/modules/VegaPandasTranslator.ts
+++ b/src/modules/VegaPandasTranslator.ts
@@ -1,0 +1,104 @@
+
+import { vegaParamPredicatesList, VegaParamPredicate, VegaAggregation } from "./VegaEncodings";
+import { GraphSpec } from "../hooks/bifrost-model";
+
+
+
+const DF = "$df"
+const filterTypes = new Set<string>(vegaParamPredicatesList)
+
+interface AggFunc {
+    (encoding: any, encodings: any[]): string
+}
+const vegaAggToPd: {[vegaAgg: string]: string | AggFunc} = {
+    'count': "count",
+  'valid': (encoding , encodings) => "TODO: Not implemented",
+  'values': (encoding , encodings) => "TODO: Not implemented",
+  // Look at this one again...
+  'missing': (encoding , encodings) => `$df = $df[pd.isnull($df["${encoding.field}]")]`,
+  // Not sure if we should groupby on this one.
+  'distinct': (encoding , encodings) => [`cols = $df.columns.to_list()`,
+  `$df = $df.drop_duplicates([${encodings.map(encoding => `${encoding.field}`)}])`].join("\n"),
+  'sum': "sum",
+  'product': "prod",
+  'mean': "mean",
+  'variance' : 'var',
+  'variancep': (encoding , encodings) => "TODO: Not implemented",
+  'stdev': "std",
+  'stdevp': (encoding , encodings) => "TODO: Not implemented",
+  'stderr': (encoding , encodings) => "TODO: Not implemented",
+  'median': "median",
+  'q1': (encoding , encodings) => "TODO: Not implemented",
+  'q3': (encoding , encodings) => "TODO: Not implemented",
+  'ci0': (encoding , encodings) => "TODO: Not implemented",
+  'ci1': (encoding , encodings) => "TODO: Not implemented",
+  'min': "min",
+  'max': "max",
+  'argmin': (encoding , encodings) => "TODO: Not implemented",
+  'argmax': (encoding , encodings) => "TODO: Not implemented",
+}
+
+
+export default class VegaPandasTranslator {
+
+    private getQueryFromFilter(filterConfig: any) {
+        return Object.keys(filterConfig).filter(key => filterTypes.has(key)).map((filterType) => {
+            let query: string;
+            switch (filterType as VegaParamPredicate) {
+                case "gte":
+                    query = `(${DF}['${filterConfig.field}'] >= ${filterConfig.gte})`
+                    break;
+                case "lte":
+                    query = `(${DF}['${filterConfig.field}'] <= ${filterConfig.lte})`
+                    break;
+                case "range":
+                    // Expects number range like {range: [0, 5]}
+                    query = `(${DF}['${filterConfig.field}'] >= ${filterConfig.gte}) & (${DF}['${filterConfig.field}'] <= ${filterConfig.lte})`
+                    break;
+                case "oneOf":
+                    query = `(${DF}['${filterConfig.field}'].isin([${filterConfig.oneOf.toString()}]))`
+                    break;
+            
+                default:
+                    query = ""
+                    break;
+            }
+            return query;
+        }).join("&")
+    }
+
+    private getAggregations(encodings: GraphSpec["encoding"]) {
+        const encodingVals = Object.values(encodings)
+        return encodingVals.filter(encoding => encoding.hasOwnProperty("aggregate")).map((encoding) => {
+            let query: string;
+            const agg = vegaAggToPd[encoding.aggregate as VegaAggregation];
+            if (typeof agg === "string") {
+                query = 
+                [`group_fields = $df.columns.to_list()`,
+                `group_fields.remove("${encoding.field}")`,
+                `$df = $df.join($df.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`].join("\n")
+            } else {
+                query = agg(encoding, encodingVals);
+            }
+            return query;
+        }).join("\n")
+    }
+        
+
+
+    convertSpecToCode(spec: GraphSpec) {
+        // Filters
+        const filterQuery = spec.transform.map((filterObj) =>  this.getQueryFromFilter(filterObj.filter)).join("&")
+        const filteredDs = filterQuery.length ?  `$df = $df[${filterQuery}]` : ""
+        // Aggregators
+        const aggregations = this.getAggregations(spec.encoding)
+        // Check 
+        let code = [
+            filteredDs, aggregations
+        ].join("\n")
+        return code
+    }
+
+
+
+}

--- a/src/modules/VegaPandasTranslator.ts
+++ b/src/modules/VegaPandasTranslator.ts
@@ -1,90 +1,106 @@
+import {
+  vegaParamPredicatesList,
+  VegaParamPredicate,
+  VegaAggregation,
+} from './VegaEncodings';
+import { GraphSpec, EncodingInfo } from '../hooks/bifrost-model';
 
-import { vegaParamPredicatesList, VegaParamPredicate, VegaAggregation } from "./VegaEncodings";
-import { GraphSpec, EncodingInfo } from "../hooks/bifrost-model";
-
-const filterTypes = new Set<string>(vegaParamPredicatesList)
+const filterTypes = new Set<string>(vegaParamPredicatesList);
 
 interface AggFunc {
-    (encoding: EncodingInfo): string
+  (encoding: EncodingInfo): string;
 }
-const vegaAggToPd: {[vegaAgg: string]: string | AggFunc} = {
-    'count': "count",
-  'valid': (encoding) => `$df.join($df.dropna().groupby(group_fields).count()["${encoding.field}"], on=group_fields, rsuffix=" valid count")`,
-  'missing': (encoding) => `$df.join($df.groupby(group_fields)["${encoding.field}"].apply(lambda x: x.isnull().sum()), on=group_fields, rsuffix=" missing")`,
-  'distinct': (encoding) => `$df.join($df.dropna().groupby(group_fields).unique()["${encoding.field}"], on=group_fields, rsuffix=" distinct")`,
-  'sum': "sum",
-  'product': "prod",
-  'mean': "mean",
-  'variance' : 'var',
-  'variancep': (encoding) => `$df.join($df.groupby(group_fields).var(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population variance")`,
-  'stdev': "std",
-  'stdevp': (encoding) => `$df.join($df.groupby(group_fields).std(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population std")`,
-  'stderr': (encoding) => `$df.join($df.groupby(group_fields).sem()["${encoding.field}"], on=group_fields, rsuffix=" stderr")`,
-  'median': "median",
-  'min': "min",
-  'max': "max",
-}
-
+const vegaAggToPd: { [vegaAgg: string]: string | AggFunc } = {
+  count: 'count',
+  valid: (encoding) =>
+    `$df.join($df.dropna().groupby(group_fields).count()["${encoding.field}"], on=group_fields, rsuffix=" valid count")`,
+  missing: (encoding) =>
+    `$df.join($df.groupby(group_fields)["${encoding.field}"].apply(lambda x: x.isnull().sum()), on=group_fields, rsuffix=" missing")`,
+  distinct: (encoding) =>
+    `$df.join($df.dropna().groupby(group_fields).unique()["${encoding.field}"], on=group_fields, rsuffix=" distinct")`,
+  sum: 'sum',
+  product: 'prod',
+  mean: 'mean',
+  variance: 'var',
+  variancep: (encoding) =>
+    `$df.join($df.groupby(group_fields).var(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population variance")`,
+  stdev: 'std',
+  stdevp: (encoding) =>
+    `$df.join($df.groupby(group_fields).std(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population std")`,
+  stderr: (encoding) =>
+    `$df.join($df.groupby(group_fields).sem()["${encoding.field}"], on=group_fields, rsuffix=" stderr")`,
+  median: 'median',
+  min: 'min',
+  max: 'max',
+};
 
 export default class VegaPandasTranslator {
+  private getQueryFromFilter(filterConfig: any) {
+    return Object.keys(filterConfig)
+      .filter((key) => filterTypes.has(key))
+      .map((filterType) => {
+        let query: string;
+        switch (filterType as VegaParamPredicate) {
+          case 'gte':
+            query = `($df['${filterConfig.field}'] >= ${filterConfig.gte})`;
+            break;
+          case 'lte':
+            query = `($df['${filterConfig.field}'] <= ${filterConfig.lte})`;
+            break;
+          case 'range':
+            // Expects number range like {range: [0, 5]}.
+            query = `($df['${filterConfig.field}'] >= ${filterConfig.gte}) & ($df['${filterConfig.field}'] <= ${filterConfig.lte})`;
+            break;
+          case 'oneOf':
+            query = `($df['${filterConfig.field}'].isin([${filterConfig.oneOf
+              .map((str: string) => `"${str}"`)
+              .toString()}]))`;
+            break;
 
-    private getQueryFromFilter(filterConfig: any) {
-        return Object.keys(filterConfig).filter(key => filterTypes.has(key)).map((filterType) => {
-            let query: string;
-            switch (filterType as VegaParamPredicate) {
-                case "gte":
-                    query = `($df['${filterConfig.field}'] >= ${filterConfig.gte})`
-                    break;
-                case "lte":
-                    query = `($df['${filterConfig.field}'] <= ${filterConfig.lte})`
-                    break;
-                case "range":
-                    // Expects number range like {range: [0, 5]}.
-                    query = `($df['${filterConfig.field}'] >= ${filterConfig.gte}) & ($df['${filterConfig.field}'] <= ${filterConfig.lte})`
-                    break;
-                case "oneOf":
-                    query = `($df['${filterConfig.field}'].isin([${filterConfig.oneOf.map((str: string) => `"${str}"`).toString()}]))`
-                    break;
-            
-                default:
-                    query = ""
-                    break;
-            }
-            return query;
-        }).join("&")
-    }
+          default:
+            query = '';
+            break;
+        }
+        return query;
+      })
+      .join('&');
+  }
 
-    private getAggregations(encodings: GraphSpec["encoding"]) {
-        const encodingVals = Object.values(encodings)
-        return encodingVals.filter(encoding => encoding.hasOwnProperty("aggregate")).map((encoding) => {
-            const agg = vegaAggToPd[encoding.aggregate as VegaAggregation];
-            const otherEncodedFields = encodingVals.filter(otherEncoding => otherEncoding !== encoding).map(otherEncoding => `"${otherEncoding.field}"`)
-            const pandasGroupFields = `group_fields = [${otherEncodedFields.toString()}]`
-            if (typeof agg === "string") {
-               return [pandasGroupFields,
-                `$df = $df.join($df.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`].join("\n")
-            } else {
-                return [pandasGroupFields,
-                `$df = ${agg(encoding)}`].join("\n");
-            }
-        }).join("\n")
-    }
-        
+  private getAggregations(encodings: GraphSpec['encoding']) {
+    const encodingVals = Object.values(encodings);
+    return encodingVals
+      .filter((encoding) => 'aggregate' in encoding)
+      .map((encoding) => {
+        const agg = vegaAggToPd[encoding.aggregate as VegaAggregation];
+        const otherEncodedFields = encodingVals
+          .filter((otherEncoding) => otherEncoding !== encoding)
+          .map((otherEncoding) => `"${otherEncoding.field}"`);
+        const pandasGroupFields = `group_fields = [${otherEncodedFields.toString()}]`;
+        if (typeof agg === 'string') {
+          return [
+            pandasGroupFields,
+            `$df = $df.join($df.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`,
+          ].join('\n');
+        } else {
+          return [pandasGroupFields, `$df = ${agg(encoding)}`].join('\n');
+        }
+      })
+      .join('\n');
+  }
 
+  convertSpecToCode(spec: GraphSpec) {
+    // Filters
+    const filterQuery = spec.transform
+      .map((filterObj) => this.getQueryFromFilter(filterObj.filter))
+      .join('&');
+    const filteredDs = filterQuery.length ? `$df = $df[${filterQuery}]` : '';
+    // Aggregators
+    const aggregations = this.getAggregations(spec.encoding);
+    // Check
+    const code = [filteredDs, aggregations].join('\n');
 
-    convertSpecToCode(spec: GraphSpec) {
-        // Filters
-        const filterQuery = spec.transform.map((filterObj) =>  this.getQueryFromFilter(filterObj.filter)).join("&")
-        const filteredDs = filterQuery.length ?  `$df = $df[${filterQuery}]` : ""
-        // Aggregators
-        const aggregations = this.getAggregations(spec.encoding)
-        // Check 
-        let code = [
-            filteredDs, aggregations
-        ].join("\n")
-        return code
-    }
+    const isAlphaNum = /\w/;
 
-
-
+    return isAlphaNum.test(code) ? code : '$df';
+  }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -39,6 +39,7 @@ export class BifrostModel extends DOMWidgetModel {
       graph_data: [],
       suggested_graphs: [],
       flags: {},
+      df_variable_name: '',
     };
   }
 


### PR DESCRIPTION
**Vega filters and aggregations can be exported to Pandas code!**
Fixes #11 

## Changes
- Added support for 16 / 22 of the aggregations in Vega for code export.
- Added support for quantitative and categorical filtering code export.

## Limitations
Since we do not have tracing integrated with the library, we currently use `df` as the dataframe variable name. The user has to manually swap this out if their data frame was not named `df`.

## Testing
1. Plot a DataFrame and open the Graph in Bifrost.
2. For each of the following, apply the change to the graph, click export code and run the code to see if the outputted data frame appears reasonable in form:
 - Apply a min/max filter to a quantitative variable
 - Apply a membership filter to a categorical variable
 - Try out several aggregations with a quantitative variable, ensuring that they do not produce errors when run.