### PR TITLE
Customize mark of the graph

### DIFF
--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -124,6 +124,7 @@ class BifrostWidget(DOMWidget):
                     "mark": kind,
                     "params": [{"name": "brush", "select": "interval"}],
                     "data": {"name": "data"},
+                    "transform": [],
                     "encoding": {
                         encoding : {"field": col, "type": types[col]} for encoding, col in zip(["x", "y", "color"], df_filter)
                     }

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -10,14 +10,23 @@
   {
    "cell_type": "code",
 <<<<<<< HEAD
+<<<<<<< HEAD
    "execution_count": 88,
 =======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
 <<<<<<< HEAD
    "execution_count": 10,
 =======
    "execution_count": 22,
 >>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
 >>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 1,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,14 +39,23 @@
   {
    "cell_type": "code",
 <<<<<<< HEAD
+<<<<<<< HEAD
    "execution_count": 89,
 =======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
 <<<<<<< HEAD
    "execution_count": 11,
 =======
    "execution_count": 23,
 >>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
 >>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 2,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
    "metadata": {},
    "outputs": [
     {
@@ -92,28 +110,46 @@
   {
    "cell_type": "code",
 <<<<<<< HEAD
+<<<<<<< HEAD
    "execution_count": 90,
 =======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
 <<<<<<< HEAD
    "execution_count": 18,
 =======
    "execution_count": 24,
 >>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
 >>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 3,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
 <<<<<<< HEAD
+<<<<<<< HEAD
        "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
 =======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
 <<<<<<< HEAD
        "model_id": "e5f90098220841be87bcd294a2166ca7",
 =======
        "model_id": "1f75c5c0a93c40ed83ff54f4a0f12a9d",
 >>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
 >>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+       "model_id": "6504b8982f684694a9271a0eaef2ee1b",
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -11,6 +11,7 @@
    "cell_type": "code",
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
    "execution_count": 88,
 =======
 =======
@@ -27,6 +28,9 @@
    "execution_count": 1,
 >>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
 >>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 10,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,6 +42,7 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
    "execution_count": 89,
@@ -56,6 +61,9 @@
    "execution_count": 2,
 >>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
 >>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 11,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [
     {
@@ -111,6 +119,7 @@
    "cell_type": "code",
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
    "execution_count": 90,
 =======
 =======
@@ -127,11 +136,15 @@
    "execution_count": 3,
 >>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
 >>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 12,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
        "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
@@ -150,11 +163,18 @@
        "model_id": "6504b8982f684694a9271a0eaef2ee1b",
 >>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
 >>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+       "model_id": "d2c03099559f466fb8c1e3cad56de512",
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
+<<<<<<< HEAD
        "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], d…"
+=======
+       "BifrostWidget(df_columns=['Name', 'Job', 'Years Worked For Jupyter'], flags={'columns_provided': True, 'kind_p…"
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
       ]
      },
      "metadata": {},
@@ -162,7 +182,11 @@
     }
    ],
    "source": [
+<<<<<<< HEAD
     "res = iris_df.bifrost.plot(x=\"sepal length (cm)\", y=\"sepal width (cm)\")"
+=======
+    "res = bar_df.bifrost.plot(x=\"Name\", y=\"Job\", kind=\"point\")"
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,32 +9,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-   "execution_count": 4,
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 88,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 10,
-=======
-   "execution_count": 22,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 1,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 10,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
->>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,32 +21,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-   "execution_count": 5,
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 89,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 11,
-=======
-   "execution_count": 23,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 2,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 11,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
->>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +30,7 @@
        "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -90,7 +40,7 @@
        "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -98,11 +48,11 @@
      "data": {
       "text/plain": [
        "Index(['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)',\n",
-       "       'petal width (cm)', 'class'],\n",
+       "       'petal width (cm)'],\n",
        "      dtype='object')"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,82 +70,23 @@
     "], columns=[\"Name\", \"Job\", \"Years Worked For Jupyter\"])\n",
     "\n",
     "iris_ds = load_iris()\n",
-    "iris_df = pd.DataFrame(iris_ds[\"data\"], columns=iris_ds[\"feature_names\"])\n",
-    "iris_df['class'] = ['iris_setosa'] * 50 + ['iris_versicolour'] * 50 + ['iris_virginica'] * 50"
+    "iris_df = pd.DataFrame(iris_ds[\"data\"], columns=iris_ds[\"feature_names\"])"
    ]
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-   "execution_count": 6,
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 90,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 18,
-=======
-   "execution_count": 24,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 3,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 12,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
->>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-<<<<<<< HEAD
-       "model_id": "cc29e453143146588ba6d2fdd26d0596",
-=======
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
        "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-       "model_id": "e5f90098220841be87bcd294a2166ca7",
-=======
-       "model_id": "1f75c5c0a93c40ed83ff54f4a0f12a9d",
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-       "model_id": "6504b8982f684694a9271a0eaef2ee1b",
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-       "model_id": "d2c03099559f466fb8c1e3cad56de512",
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
->>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-<<<<<<< HEAD
-       "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)', 'c…"
-=======
-<<<<<<< HEAD
        "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], d…"
-=======
-       "BifrostWidget(df_columns=['Name', 'Job', 'Years Worked For Jupyter'], flags={'columns_provided': True, 'kind_p…"
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
->>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
       ]
      },
      "metadata": {},
@@ -203,16 +94,12 @@
     }
    ],
    "source": [
-<<<<<<< HEAD
     "res = iris_df.bifrost.plot(x=\"sepal length (cm)\", y=\"sepal width (cm)\")"
-=======
-    "res = bar_df.bifrost.plot(x=\"Name\", y=\"Job\", kind=\"point\")"
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +126,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -253,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -30,7 +30,7 @@
        "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -40,7 +40,7 @@
        "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -48,11 +48,11 @@
      "data": {
       "text/plain": [
        "Index(['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)',\n",
-       "       'petal width (cm)'],\n",
+       "       'petal width (cm)', 'class'],\n",
        "      dtype='object')"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,23 +70,24 @@
     "], columns=[\"Name\", \"Job\", \"Years Worked For Jupyter\"])\n",
     "\n",
     "iris_ds = load_iris()\n",
-    "iris_df = pd.DataFrame(iris_ds[\"data\"], columns=iris_ds[\"feature_names\"])"
+    "iris_df = pd.DataFrame(iris_ds[\"data\"], columns=iris_ds[\"feature_names\"])\n",
+    "iris_df['class'] = ['iris_setosa'] * 50 + ['iris_versicolour'] * 50 + ['iris_virginica'] * 50"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
+       "model_id": "cc29e453143146588ba6d2fdd26d0596",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], d…"
+       "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)', 'c…"
       ]
      },
      "metadata": {},
@@ -99,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +127,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -140,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,28 +9,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 88,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 10,
-=======
-   "execution_count": 22,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 1,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 10,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,28 +21,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 89,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 11,
-=======
-   "execution_count": 23,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 2,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 11,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [
     {
@@ -117,64 +75,18 @@
   },
   {
    "cell_type": "code",
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
    "execution_count": 90,
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-   "execution_count": 18,
-=======
-   "execution_count": 24,
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-   "execution_count": 3,
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-   "execution_count": 12,
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
        "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
-=======
-=======
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-<<<<<<< HEAD
-       "model_id": "e5f90098220841be87bcd294a2166ca7",
-=======
-       "model_id": "1f75c5c0a93c40ed83ff54f4a0f12a9d",
->>>>>>> 5f66182 (Implemented mark customization)
-<<<<<<< HEAD
->>>>>>> 0893756 (Implemented mark customization)
-=======
-=======
-       "model_id": "6504b8982f684694a9271a0eaef2ee1b",
->>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
->>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
-=======
-       "model_id": "d2c03099559f466fb8c1e3cad56de512",
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-<<<<<<< HEAD
        "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], d…"
-=======
-       "BifrostWidget(df_columns=['Name', 'Job', 'Years Worked For Jupyter'], flags={'columns_provided': True, 'kind_p…"
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
       ]
      },
      "metadata": {},
@@ -182,11 +94,7 @@
     }
    ],
    "source": [
-<<<<<<< HEAD
     "res = iris_df.bifrost.plot(x=\"sepal length (cm)\", y=\"sepal width (cm)\")"
-=======
-    "res = bar_df.bifrost.plot(x=\"Name\", y=\"Job\", kind=\"point\")"
->>>>>>> 52d8dd6 (Implemented mark customization subtab)
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,32 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 4,
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+   "execution_count": 88,
+=======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+<<<<<<< HEAD
+   "execution_count": 10,
+=======
+   "execution_count": 22,
+>>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
+>>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 1,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 10,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
+>>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +46,32 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 5,
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+   "execution_count": 89,
+=======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+<<<<<<< HEAD
+   "execution_count": 11,
+=======
+   "execution_count": 23,
+>>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
+>>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 2,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 11,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
+>>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [
     {
@@ -76,18 +126,76 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 6,
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+   "execution_count": 90,
+=======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+<<<<<<< HEAD
+   "execution_count": 18,
+=======
+   "execution_count": 24,
+>>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
+>>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+   "execution_count": 3,
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+   "execution_count": 12,
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
+>>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
+<<<<<<< HEAD
        "model_id": "cc29e453143146588ba6d2fdd26d0596",
+=======
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+       "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
+=======
+=======
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+<<<<<<< HEAD
+       "model_id": "e5f90098220841be87bcd294a2166ca7",
+=======
+       "model_id": "1f75c5c0a93c40ed83ff54f4a0f12a9d",
+>>>>>>> 5f66182 (Implemented mark customization)
+<<<<<<< HEAD
+>>>>>>> 0893756 (Implemented mark customization)
+=======
+=======
+       "model_id": "6504b8982f684694a9271a0eaef2ee1b",
+>>>>>>> d60a3bf (Added vegalite categorial and quantitive chart lists)
+>>>>>>> df872e6 (Added vegalite categorial and quantitive chart lists)
+=======
+       "model_id": "d2c03099559f466fb8c1e3cad56de512",
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
+>>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
+<<<<<<< HEAD
        "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)', 'c…"
+=======
+<<<<<<< HEAD
+       "BifrostWidget(df_columns=['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], d…"
+=======
+       "BifrostWidget(df_columns=['Name', 'Job', 'Years Worked For Jupyter'], flags={'columns_provided': True, 'kind_p…"
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
+>>>>>>> 85f30aa537c7ab4ba78cf395dffbea8190952afa
       ]
      },
      "metadata": {},
@@ -95,7 +203,11 @@
     }
    ],
    "source": [
+<<<<<<< HEAD
     "res = iris_df.bifrost.plot(x=\"sepal length (cm)\", y=\"sepal width (cm)\")"
+=======
+    "res = bar_df.bifrost.plot(x=\"Name\", y=\"Job\", kind=\"point\")"
+>>>>>>> 52d8dd6 (Implemented mark customization subtab)
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,15 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 88,
+=======
+<<<<<<< HEAD
+   "execution_count": 10,
+=======
+   "execution_count": 22,
+>>>>>>> 5f66182 (Implemented mark customization)
+>>>>>>> 0893756 (Implemented mark customization)
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +29,15 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 89,
+=======
+<<<<<<< HEAD
+   "execution_count": 11,
+=======
+   "execution_count": 23,
+>>>>>>> 5f66182 (Implemented mark customization)
+>>>>>>> 0893756 (Implemented mark customization)
    "metadata": {},
    "outputs": [
     {
@@ -75,13 +91,29 @@
   },
   {
    "cell_type": "code",
+<<<<<<< HEAD
    "execution_count": 90,
+=======
+<<<<<<< HEAD
+   "execution_count": 18,
+=======
+   "execution_count": 24,
+>>>>>>> 5f66182 (Implemented mark customization)
+>>>>>>> 0893756 (Implemented mark customization)
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
+<<<<<<< HEAD
        "model_id": "f4e3cc8662f4458e9d530cfae50168d4",
+=======
+<<<<<<< HEAD
+       "model_id": "e5f90098220841be87bcd294a2166ca7",
+=======
+       "model_id": "1f75c5c0a93c40ed83ff54f4a0f12a9d",
+>>>>>>> 5f66182 (Implemented mark customization)
+>>>>>>> 0893756 (Implemented mark customization)
        "version_major": 2,
        "version_minor": 0
       },

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -15,45 +15,58 @@ import VisualizationScreen from './VisualizationScreen';
 const globalStyles = (theme: any) => css`
   // Global styles for the widget
   //===========================================================
-  * {
-    box-sizing: border-box;
-  }
-
-  button {
-    cursor: pointer;
-    transition: transform 0.4s;
-    background-color: ${theme.color.primary.dark};
-    color: white;
-    font-weight: 700;
-    padding: 10px 15px;
-    border-radius: 7px;
-    font-size: 16px;
-    border: none;
-
-    &:active {
-      transform: scale(0.95);
+  .bifrost-widget {
+    * {
+      box-sizing: border-box;
     }
 
-    &.wrapper {
+    button {
+      cursor: pointer;
+      transition: transform 0.4s;
+      background-color: ${theme.color.primary.dark};
+      color: white;
+      font-weight: 700;
+      padding: 10px 15px;
+      border-radius: 7px;
+      font-size: 16px;
       border: none;
-      background: transparent;
-      margin: 0;
-      padding: 0;
-      margin-right: 15px;
-      color: initial;
+
+      &:active {
+        transform: scale(0.95);
+      }
+
+      &.wrapper {
+        border: none;
+        background: transparent;
+        margin: 0;
+        padding: 0;
+        margin-right: 15px;
+        color: initial;
+      }
+
+      &.next-button {
+        padding: 0;
+        background-color: ${theme.color.primary.dark};
+        border: none;
+        border-radius: 50%;
+        cursor: pointer;
+        height: 28px;
+        width: 28px;
+        margin-left: 20px;
+      }
     }
-  }
 
-  h1 {
-    font-size: 35px;
-    font-weight: 800;
-    margin: 10px 0;
-    margin-bottom: 15px;
-  }
+    h1 {
+      font-size: 35px;
+      font-weight: 800;
+      margin: 10px 0;
+      margin-bottom: 15px;
+    }
 
-  h2 {
-    font-size: 25px;
-    font-weight: 800;
+    h2 {
+      font-size: 25px;
+      font-weight: 800;
+    }
   }
 `;
 

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -22,7 +22,7 @@ const globalStyles = (theme: any) => css`
   button {
     cursor: pointer;
     transition: transform 0.4s;
-    background-color: ${theme.color.primary[0]};
+    background-color: ${theme.color.primary.dark};
     color: white;
     font-weight: 700;
     padding: 10px 15px;

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { WidgetModel } from '@jupyter-widgets/base';
 import {
   useModelState,
-  Flags,
+  Args,
   BifrostModelContext,
 } from '../hooks/bifrost-model';
 import theme from '../theme';
@@ -73,12 +73,12 @@ export default function BifrostReactWidget(props: BifrostReactWidgetProps) {
 }
 
 function BifrostReactWidgetDisplay() {
-  const flags = useModelState<Flags>('flags')[0];
+  const args = useModelState<Args>('plot_function_args')[0];
 
   const [screenName, setScreenName] = useState<string>(
-    !flags['columns_provided']
+    !(args['x'] && args['y'])
       ? 'columnChooser'
-      : !flags['kind_provided']
+      : !args['kind']
       ? 'chartChooser'
       : 'straight_visualize'
   );
@@ -93,6 +93,7 @@ function BifrostReactWidgetDisplay() {
         <OnboardingWidget
           screenName={screenName}
           setScreenName={setScreenName}
+          args={args}
         />
       )}
     </div>

--- a/src/components/Onboarding/ChartChooser.tsx
+++ b/src/components/Onboarding/ChartChooser.tsx
@@ -94,6 +94,9 @@ export default function ChartChooser(props: ChartChooserProps) {
             inline: 'end',
           });
         break;
+      case 'Backspace':
+        props.onBack && props.onBack();
+        break;
     }
   }
 
@@ -119,7 +122,11 @@ export default function ChartChooser(props: ChartChooserProps) {
             key={`spec_${i}`}
             onClick={() => setSelectedIndex(i)}
           >
-            <VegaLite spec={spec as VisualizationSpec} data={data} />
+            <VegaLite
+              spec={spec as VisualizationSpec}
+              data={data}
+              actions={false}
+            />
             <div
               className="graph-info"
               style={{

--- a/src/components/Onboarding/ChartChooser.tsx
+++ b/src/components/Onboarding/ChartChooser.tsx
@@ -28,7 +28,7 @@ const suggestedChartCss = css`
     border-radius: 5px;
     transition: border-color 0.5s;
     &.selected {
-      border: 10px solid ${theme.color.primary[2]};
+      border: 10px solid ${theme.color.onSelected};
     }
   }
 `;

--- a/src/components/Onboarding/ChartChooser.tsx
+++ b/src/components/Onboarding/ChartChooser.tsx
@@ -28,7 +28,7 @@ const suggestedChartCss = css`
     border-radius: 5px;
     transition: border-color 0.5s;
     &.selected {
-      border: 10px solid ${theme.color.onSelected};
+      border: 10px solid ${theme.color.primary.light};
     }
   }
 `;

--- a/src/components/Onboarding/ColumnScreen.tsx
+++ b/src/components/Onboarding/ColumnScreen.tsx
@@ -4,7 +4,6 @@ import { jsx, css } from '@emotion/react';
 import React, { useState, useRef } from 'react';
 import NavHeader from './NavHeader';
 import SearchBar from '../ui-widgets/SearchBar';
-// import Tag from '../ui-widgets/Tag';
 import Pill from '../ui-widgets/Pill';
 
 import {
@@ -12,16 +11,15 @@ import {
   GraphData,
   useModelState,
   SuggestedGraphs,
+  Args,
 } from '../../hooks/bifrost-model';
 import { build } from 'compassql/build/src/schema';
 import { recommend } from 'compassql/build/src/recommend';
 import { mapLeaves } from 'compassql/build/src/result';
 import { SpecQueryModel } from 'compassql/build/src/model';
 import { Query } from 'compassql/build/src/query/query';
-import { X } from 'react-feather';
+import { Lock, X } from 'react-feather';
 import { useEffect } from 'react';
-
-// TODO: get this from the backend
 
 const columnScreenCss = css`
   display: flex;
@@ -46,6 +44,10 @@ const columnScreenCss = css`
     border: 1px solid #aaa;
     border-radius: 20%;
     margin-right: 6px;
+  }
+
+  input[type='checkbox']:disabled {
+    cursor: default;
   }
 
   input[type='checkbox']:checked {
@@ -77,8 +79,6 @@ const columnScreenCss = css`
   .tag-content-wrapper {
     display: flex;
     justify-content: space-between;
-    /* height: 23px;
-    width: fit-content; */
     white-space: nowrap;
     overflow: hidden;
     align-items: center;
@@ -102,7 +102,7 @@ const columnScreenCss = css`
 interface ColumnScreenProps {
   onNext: () => void;
   onBack?: () => void;
-  preSelectedColumns: Set<string>;
+  args: Args;
 }
 
 export default function ColumnScreen(props: ColumnScreenProps) {
@@ -120,9 +120,14 @@ export default function ColumnScreen(props: ColumnScreenProps) {
 
   const [focusedIdx, setFocusedIdx] = useState<number>(0);
 
-  const [selectedColumns, setSelectedColumns] = useState(
-    props.preSelectedColumns
-  );
+  const preSelectedColumns = new Set<string>();
+  for (const [_, value] of Object.entries(props.args)) {
+    if (value) {
+      preSelectedColumns.add(value as string);
+    }
+  }
+
+  const [selectedColumns, setSelectedColumns] = useState(preSelectedColumns);
   const keyPressed = { Shift: false, Enter: false };
 
   useEffect(() => {
@@ -136,14 +141,36 @@ export default function ColumnScreen(props: ColumnScreenProps) {
     const opt = {};
 
     const schema = build(data, opt);
+
     const filteredEncodings = spec.spec.encodings.filter((encoding: any) =>
       selectedColumns.has(encoding.field)
     );
+
     const filteredSpecs: Query[] = [];
-    for (let i = 0; i < filteredEncodings.length - 1; i++) {
-      filteredSpecs.push({
-        spec: { ...spec.spec, encodings: filteredEncodings.slice(i, i + 3) },
-      });
+
+    if (!props.args.x && !props.args.y) {
+      for (let i = 0; i < filteredEncodings.length - 1; i++) {
+        filteredSpecs.push({
+          spec: { ...spec.spec, encodings: filteredEncodings.slice(i, i + 3) },
+        });
+      }
+    } else {
+      if (selectedColumns.size < 3) {
+        for (const encoding of spec.spec.encodings) {
+          if ((encoding as any).channel === '?') {
+            filteredSpecs.push({
+              spec: {
+                ...spec.spec,
+                encodings: [...filteredEncodings, encoding],
+              },
+            });
+          }
+        }
+      } else {
+        filteredSpecs.push({
+          spec: { ...spec.spec, encodings: filteredEncodings },
+        });
+      }
     }
 
     const items = filteredSpecs
@@ -202,18 +229,26 @@ export default function ColumnScreen(props: ColumnScreenProps) {
           keyPressed['Enter'] = true;
           submit();
         } else {
-          if (columnChoices.includes(query)) {
-            const updatedSet = new Set(selectedColumns);
-            updatedSet.add(query);
-            setSelectedColumns(updatedSet);
-          } else {
-            const choice = optionsRef.current?.querySelector(
-              '.choice.focused input'
-            ) as HTMLInputElement;
+          const choice = optionsRef.current?.querySelector(
+            '.choice.focused input'
+          ) as HTMLInputElement;
 
-            if (choice) {
+          if (choice && !preSelectedColumns.has(choice.value)) {
+            if (columnChoices.includes(query)) {
               const updatedSet = new Set(selectedColumns);
-              updatedSet.add(choice.value);
+              if (updatedSet.has(query)) {
+                updatedSet.delete(query);
+              } else {
+                updatedSet.add(query);
+              }
+              setSelectedColumns(updatedSet);
+            } else {
+              const updatedSet = new Set(selectedColumns);
+              if (updatedSet.has(choice.value)) {
+                updatedSet.delete(choice.value);
+              } else {
+                updatedSet.add(choice.value);
+              }
               setSelectedColumns(updatedSet);
             }
           }
@@ -224,16 +259,13 @@ export default function ColumnScreen(props: ColumnScreenProps) {
           e.preventDefault();
           e.stopPropagation();
 
-          const tags = document.querySelectorAll('.content-wrapper');
-          if (tags.length !== 0) {
-            const updatedSet = new Set(selectedColumns);
-            const tagName = (
-              tags[tags.length - 1].getElementsByTagName(
-                'span'
-              )[0] as HTMLSpanElement
-            ).textContent;
+          const choice = optionsRef.current?.querySelector(
+            '.choice.focused input'
+          ) as HTMLInputElement;
 
-            tagName && updatedSet.delete(tagName);
+          if (choice && !preSelectedColumns.has(choice.value)) {
+            const updatedSet = new Set(selectedColumns);
+            updatedSet.delete(choice.value);
             setSelectedColumns(updatedSet);
           }
         }
@@ -295,13 +327,17 @@ export default function ColumnScreen(props: ColumnScreenProps) {
                   className={i === focusedIdx ? 'choice focused' : 'choice'}
                   key={col}
                 >
-                  <input
-                    className={`choice_${col}`}
-                    type="checkbox"
-                    value={col}
-                    onChange={handleCheckboxChange}
-                    checked={selectedColumns.has(col)}
-                  />{' '}
+                  {preSelectedColumns.has(col) ? (
+                    <Lock size={15} style={{ marginRight: '6px' }} />
+                  ) : (
+                    <input
+                      className={`choice_${col}`}
+                      type="checkbox"
+                      value={col}
+                      onChange={handleCheckboxChange}
+                      checked={selectedColumns.has(col)}
+                    />
+                  )}
                   {col}
                 </label>
               );

--- a/src/components/Onboarding/NavHeader.tsx
+++ b/src/components/Onboarding/NavHeader.tsx
@@ -64,7 +64,7 @@ export default function NavHeader(props: HeaderProps) {
 
 const nextButtonCss = (theme: any) => css`
   padding: 0;
-  background-color: ${theme.color.primary[0]};
+  background-color: ${theme.color.primary.dark};
   border: none;
   border-radius: 50%;
   cursor: pointer;

--- a/src/components/Onboarding/NavHeader.tsx
+++ b/src/components/Onboarding/NavHeader.tsx
@@ -62,20 +62,9 @@ export default function NavHeader(props: HeaderProps) {
   );
 }
 
-const nextButtonCss = (theme: any) => css`
-  padding: 0;
-  background-color: ${theme.color.primary.dark};
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  height: 28px;
-  width: 28px;
-  margin-left: 20px;
-`;
-
 function NextButton(props: { onClick: () => void }) {
   return (
-    <button onClick={props.onClick} css={nextButtonCss}>
+    <button className={'next-button'} onClick={props.onClick}>
       <ArrowRight size={20} color="white" strokeWidth="4" />
     </button>
   );

--- a/src/components/Onboarding/OnboardingWidget.tsx
+++ b/src/components/Onboarding/OnboardingWidget.tsx
@@ -7,6 +7,7 @@ import {
   SuggestedGraphs,
   GraphData,
   QuerySpec,
+  Args,
 } from '../../hooks/bifrost-model';
 
 import { useState } from 'react';
@@ -20,11 +21,11 @@ import { build } from 'compassql/build/src/schema';
 import { recommend } from 'compassql/build/src/recommend';
 import { mapLeaves } from 'compassql/build/src/result';
 import { SpecQueryModel } from 'compassql/build/src/model';
-import { FieldQuery } from 'compassql/build/src/query/encoding';
 
 interface onboardingWidgetProps {
   screenName: string;
   setScreenName: React.Dispatch<React.SetStateAction<string>>;
+  args: Args;
 }
 
 export default function OnboardingWidget(props: onboardingWidgetProps) {
@@ -33,26 +34,15 @@ export default function OnboardingWidget(props: onboardingWidgetProps) {
     useModelState<SuggestedGraphs>('suggested_graphs');
   const querySpec = useModelState<QuerySpec>('query_spec')[0];
   const data = useModelState<GraphData>('graph_data')[0];
-  const columnChoices = useModelState<string[]>('df_columns')[0];
 
   let Screen: JSX.Element;
-  const preSelectedColumns = new Set<string>();
 
   switch (props.screenName) {
     case 'columnChooser':
-      querySpec.spec.encodings.forEach((encoding: FieldQuery) => {
-        if (
-          encoding.channel !== '?' &&
-          columnChoices.includes(encoding.field as string)
-        ) {
-          preSelectedColumns.add(encoding.field as string);
-        }
-      });
-
       Screen = (
         <ColumnScreen
           onNext={() => props.setScreenName('chartChooser')}
-          preSelectedColumns={preSelectedColumns}
+          args={props.args}
         />
       );
       break;
@@ -99,19 +89,10 @@ export default function OnboardingWidget(props: onboardingWidgetProps) {
       );
       break;
     default:
-      querySpec.spec.encodings.forEach((encoding: FieldQuery) => {
-        if (
-          encoding.channel !== '?' &&
-          columnChoices.includes(encoding.field as string)
-        ) {
-          preSelectedColumns.add(encoding.field as string);
-        }
-      });
-
       Screen = (
         <ColumnScreen
           onNext={() => props.setScreenName('chartChooser')}
-          preSelectedColumns={preSelectedColumns}
+          args={props.args}
         />
       );
       break;

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -3,7 +3,7 @@ import { css, jsx } from '@emotion/react';
 import { useState } from 'react';
 import VariablesTab from './Tabs/VariablesTab';
 import HistoryTab from './Tabs/HistoryTab';
-import CustomizationTab from './Tabs/CustomizationTab';
+import CustomizationTab from './Tabs/CustomizationTab/CustomizationTab';
 import { useModelState, GraphSpec } from '../../hooks/bifrost-model';
 import VegaPandasTranslator from '../../modules/VegaPandasTranslator';
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -49,6 +49,7 @@ const tabBarCss = css`
     list-style: none;
     padding: 0;
     margin: 0;
+    justify-content: space-between;
   }
   li {
     padding: 15px 30px;
@@ -59,6 +60,8 @@ const tabBarCss = css`
 
     border: 1px solid #d4d4d4;
     border-bottom: none;
+    width: calc(100% / 3);
+    text-align: center;
 
     &.selected {
       font-weight: 800;

--- a/src/components/Sidebar/Tabs/CustomizationTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function CustomizationTab() {
-  return <h1>Customization Tab</h1>;
-}

--- a/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
@@ -2,8 +2,10 @@
 import { css, jsx } from '@emotion/react';
 import { useState } from 'react';
 import MarkSubTab from './MarkSubTab';
-import ScaleSubTab from './ScaleSubtab';
+import ScaleSubTab from './ScaleSubTab';
 import StyleSubTab from './StyleSubTab';
+
+import theme from '../../../../theme';
 
 import { useModelState, GraphSpec } from '../../../../hooks/bifrost-model';
 
@@ -30,7 +32,7 @@ const subTabCss = css`
 
     &.selected {
       font-weight: 800;
-      border-bottom: 2px solid #771c79;
+      border-bottom: 2px solid ${theme.color.primary.dark};
     }
   }
 `;

--- a/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
@@ -56,7 +56,7 @@ export default function CustomizationTab() {
           {subTabs.map((subtab) => {
             return (
               <li
-                className={subtab == selectedTab ? 'selected' : ''}
+                className={subtab === selectedTab ? 'selected' : ''}
                 onClick={() => setSelectedTab(subtab)}
                 key={subtab}
               >

--- a/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/CustomizationTab.tsx
@@ -1,0 +1,74 @@
+/** @jsx jsx */
+import { css, jsx } from '@emotion/react';
+import { useState } from 'react';
+import MarkSubTab from './MarkSubTab';
+import ScaleSubTab from './ScaleSubtab';
+import StyleSubTab from './StyleSubTab';
+
+import { useModelState, GraphSpec } from '../../../../hooks/bifrost-model';
+
+export interface CustomizeSubTapProps {
+  spec: GraphSpec;
+  setSpec: (val: GraphSpec, options?: any) => void;
+}
+
+//TODO: factor out this css to global tab css
+const subTabCss = css`
+  ul {
+    display: flex;
+    justify-content: space-between;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    background: white;
+    box-shadow: 0 4px 4px lightgrey;
+  }
+  li {
+    padding: 15px 30px;
+    cursor: pointer;
+    border-bottom: none;
+
+    &.selected {
+      font-weight: 800;
+      border-bottom: 2px solid #771c79;
+    }
+  }
+`;
+
+const subtabMapping: {
+  [name: string]: (props: CustomizeSubTapProps) => jsx.JSX.Element;
+} = {
+  Mark: MarkSubTab,
+  Scale: ScaleSubTab,
+  Style: StyleSubTab,
+};
+
+export default function CustomizationTab() {
+  const subTabs = ['Mark', 'Scale', 'Style'];
+  const [selectedTab, setSelectedTab] = useState<string>(subTabs[0]);
+  const [graphSpec, setGraphSpec] = useModelState<GraphSpec>('graph_spec');
+  const TabContents = subtabMapping[selectedTab];
+
+  return (
+    <div className="customize">
+      <section className="subtab" css={subTabCss}>
+        <ul>
+          {subTabs.map((subtab) => {
+            return (
+              <li
+                className={subtab == selectedTab ? 'selected' : ''}
+                onClick={() => setSelectedTab(subtab)}
+                key={subtab}
+              >
+                {subtab}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+      <section>
+        <TabContents spec={graphSpec} setSpec={setGraphSpec} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -76,7 +76,10 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
         {results
           .filter(({ choice: kind }) => {
             const channels = Object.keys(props.spec.encoding);
-            if (channels.length === 0) {
+            if (
+              channels.length === 0 ||
+              (!('x' in props.spec.encoding) && !('y' in props.spec.encoding))
+            ) {
               return false;
             }
 
@@ -85,13 +88,6 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
               ('y' in props.spec.encoding && !('x' in props.spec.encoding))
             ) {
               return !(kind === 'arc');
-            }
-
-            if (
-              !('x' in props.spec.encoding) &&
-              !('y' in props.spec.encoding)
-            ) {
-              return false;
             }
 
             const spec = produce(props.spec, (draftSpec: GraphSpec) => {

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from 'react';
-import { VegaChart, vegaChartList } from '../../../../modules/VegaEncodings';
+import {
+  VegaChart,
+  vegaChartList,
+  // vegaCategoricalChartList,
+  // vegaQuantitativeChartList,
+} from '../../../../modules/VegaEncodings';
 import SearchBar from '../../../ui-widgets/SearchBar';
 import { CustomizeSubTapProps } from './CustomizationTab';
 import { GraphSpec, useModelState } from '../../../../hooks/bifrost-model';
@@ -13,6 +18,7 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
     data,
   }))[0];
 
+  console.log(props.spec);
   return (
     <div className="mark-options">
       <SearchBar
@@ -28,7 +34,7 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
         return (
           <div className={`option_${kind}`} key={kind}>
             <VegaLite spec={spec as VisualizationSpec} data={data} />
-            <span>{kind}</span>;
+            <span>{kind}</span>
           </div>
         );
       })}

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -27,7 +27,7 @@ const markOptionCss = css`
   flex-direction: column;
 
   &.selected {
-    border: 5px solid ${theme.color.primary[2]};
+    border: 5px solid ${theme.color.onSelected};
 
     span {
       font-weight: bold;

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -1,43 +1,140 @@
-import React, { useState } from 'react';
+/** @jsx jsx */
+import { jsx, css } from '@emotion/react';
+import { useState } from 'react';
+
 import {
-  VegaChart,
+  vegaCategoricalChartList,
   vegaChartList,
-  // vegaCategoricalChartList,
-  // vegaQuantitativeChartList,
+  vegaTemporalChartList,
 } from '../../../../modules/VegaEncodings';
 import SearchBar from '../../../ui-widgets/SearchBar';
 import { CustomizeSubTapProps } from './CustomizationTab';
 import { GraphSpec, useModelState } from '../../../../hooks/bifrost-model';
 import { PlainObject, VegaLite, VisualizationSpec } from 'react-vega';
 import produce from 'immer';
+import theme from '../../../../theme';
+
+const markOptionsListCss = css`
+  display: flex;
+  flex-wrap: wrap;
+  overflow: scroll;
+  list-style: none;
+  padding: 0px;
+`;
+
+const markOptionCss = css`
+  display: flex;
+  flex-direction: column;
+
+  &.selected {
+    border: 5px solid ${theme.color.primary[2]};
+
+    span {
+      font-weight: bold;
+    }
+  }
+`;
 
 export default function MarkSubTab(props: CustomizeSubTapProps) {
   const [searchValue, setSearchValue] = useState<string>('');
-  const [results, setResults] = useState<VegaChart[]>(vegaChartList);
+  const [results, setResults] = useState(
+    vegaChartList.map((choice, index) => ({ choice, index }))
+  );
   const data = useModelState<PlainObject>('graph_data', (data) => ({
     data,
   }))[0];
+  const [selectedMark, setSelectedMark] = useState<
+    string | Record<string, any>
+  >(props.spec.mark);
 
-  console.log(props.spec);
+  function handleOnClick(spec: GraphSpec) {
+    const newSpec = produce(spec, (draftSpec: GraphSpec) => {
+      draftSpec['width'] = props.spec.width;
+      draftSpec['height'] = props.spec.height;
+    });
+
+    setSelectedMark(newSpec.mark);
+    props.setSpec(newSpec);
+  }
+
   return (
-    <div className="mark-options">
+    <div className="mark-options-wrapper" style={{ width: '100%' }}>
       <SearchBar
         choices={vegaChartList}
         onResultsChange={setResults}
         onChange={setSearchValue}
         value={searchValue}
       />
-      {results.map((kind) => {
-        const spec = produce(props.spec, (draftSpec: GraphSpec) => {
-          draftSpec.mark = kind;
-        });
-        return (
-          <div className={`option_${kind}`} key={kind}>
-            <VegaLite spec={spec as VisualizationSpec} data={data} />
-            <span>{kind}</span>
-          </div>
-        );
-      })}
+      <ul className="mark-options" css={markOptionsListCss}>
+        {results.map(({ choice: kind }) => {
+          let shouldSkip = false;
+          const spec = produce(props.spec, (draftSpec: GraphSpec) => {
+            draftSpec['width'] = 100;
+            draftSpec['height'] = 100;
+            if (vegaCategoricalChartList.includes(kind)) {
+              const x = draftSpec.encoding['x'];
+              const y = draftSpec.encoding['y'];
+              if (
+                (x['type'] === 'quantitative' && y['type'] === 'nominal') ||
+                (y['type'] === 'quantitative' && x['type'] === 'nominal')
+              ) {
+                if (kind === 'errorband') {
+                  draftSpec.mark = { type: kind, extent: 'ci', borders: true };
+                } else if (kind === 'errorbar') {
+                  draftSpec.mark = { type: kind, extent: 'ci', ticks: true };
+                } else if (kind === 'arc') {
+                  if (x['type'] === 'quantitative') {
+                    draftSpec['encoding']['theta'] = x;
+                    draftSpec['encoding']['color'] = y;
+                  } else {
+                    draftSpec['encoding']['theta'] = y;
+                    draftSpec['encoding']['color'] = x;
+                  }
+                } else if (kind === 'boxplot') {
+                  draftSpec.mark = { type: kind, extent: 'min-max' };
+                }
+              } else {
+                shouldSkip = true;
+              }
+            } else if (vegaTemporalChartList.includes(kind)) {
+              const xType = draftSpec['encoding']['x']['type'];
+              const yType = draftSpec['encoding']['y']['type'];
+              if (
+                ['temporal', 'ordinal'].includes(xType) &&
+                yType === 'quantitative'
+              ) {
+                draftSpec.mark = kind;
+              } else {
+                shouldSkip = true;
+              }
+            } else {
+              draftSpec.mark = kind;
+            }
+          });
+          if (shouldSkip) {
+            return null;
+          }
+
+          return (
+            <li
+              className={
+                selectedMark === kind
+                  ? `option_${kind} selected`
+                  : `option_${kind}`
+              }
+              key={kind}
+              onClick={() => handleOnClick(spec)}
+              css={markOptionCss}
+            >
+              <VegaLite
+                spec={spec as VisualizationSpec}
+                data={data}
+                actions={false}
+              />
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { VegaChart, vegaChartList } from '../../../../modules/VegaEncodings';
+import SearchBar from '../../../ui-widgets/SearchBar';
+import { CustomizeSubTapProps } from './CustomizationTab';
+import { GraphSpec, useModelState } from '../../../../hooks/bifrost-model';
+import { PlainObject, VegaLite, VisualizationSpec } from 'react-vega';
+import produce from 'immer';
+
+export default function MarkSubTab(props: CustomizeSubTapProps) {
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [results, setResults] = useState<VegaChart[]>(vegaChartList);
+  const data = useModelState<PlainObject>('graph_data', (data) => ({
+    data,
+  }))[0];
+
+  return (
+    <div className="mark-options">
+      <SearchBar
+        choices={vegaChartList}
+        onResultsChange={setResults}
+        onChange={setSearchValue}
+        value={searchValue}
+      />
+      {results.map((kind) => {
+        const spec = produce(props.spec, (draftSpec: GraphSpec) => {
+          draftSpec.mark = kind;
+        });
+        return (
+          <div className={`option_${kind}`} key={kind}>
+            <VegaLite spec={spec as VisualizationSpec} data={data} />
+            <span>{kind}</span>;
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -27,7 +27,7 @@ const markOptionCss = css`
   flex-direction: column;
 
   &.selected {
-    border: 5px solid ${theme.color.onSelected};
+    border: 5px solid ${theme.color.primary.light};
 
     span {
       font-weight: bold;

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -75,6 +75,25 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
       <ul className="mark-options" css={markOptionsListCss}>
         {results
           .filter(({ choice: kind }) => {
+            const channels = Object.keys(props.spec.encoding);
+            if (channels.length === 0) {
+              return false;
+            }
+
+            if (
+              ('x' in props.spec.encoding && !('y' in props.spec.encoding)) ||
+              ('y' in props.spec.encoding && !('x' in props.spec.encoding))
+            ) {
+              return !(kind === 'arc');
+            }
+
+            if (
+              !('x' in props.spec.encoding) &&
+              !('y' in props.spec.encoding)
+            ) {
+              return false;
+            }
+
             const spec = produce(props.spec, (draftSpec: GraphSpec) => {
               preprocessEncoding(draftSpec);
             });
@@ -82,25 +101,18 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
             if (vegaCategoricalChartList.includes(kind)) {
               const x = spec['encoding']['x'];
               const y = spec['encoding']['y'];
-              if (
+              return (
                 (x['type'] === 'quantitative' && y['type'] === 'nominal') ||
                 (y['type'] === 'quantitative' && x['type'] === 'nominal')
-              ) {
-                return true;
-              } else {
-                return false;
-              }
+              );
             } else if (vegaTemporalChartList.includes(kind)) {
               const xType = spec['encoding']['x']['type'];
               const yType = spec['encoding']['y']['type'];
-              if (
+
+              return (
                 ['temporal', 'ordinal'].includes(xType) &&
                 yType === 'quantitative'
-              ) {
-                return true;
-              } else {
-                return false;
-              }
+              );
             } else {
               return true;
             }
@@ -117,7 +129,7 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
                 convertToCategoricalChartsEncoding(draftSpec, kind);
               }
             });
-
+            console.log(spec);
             return (
               <li
                 className={

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -66,7 +66,84 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
         value={searchValue}
       />
       <ul className="mark-options" css={markOptionsListCss}>
-        {results.map(({ choice: kind }) => {
+        {results
+          .filter(({ choice: kind }) => {
+            if (vegaCategoricalChartList.includes(kind)) {
+              const x = props.spec['encoding']['x'];
+              const y = props.spec['encoding']['y'];
+              if (
+                (x['type'] === 'quantitative' && y['type'] === 'nominal') ||
+                (y['type'] === 'quantitative' && x['type'] === 'nominal')
+              ) {
+                return true;
+              } else {
+                return false;
+              }
+            } else if (vegaTemporalChartList.includes(kind)) {
+              const xType = props.spec['encoding']['x']['type'];
+              const yType = props.spec['encoding']['y']['type'];
+              if (
+                ['temporal', 'ordinal'].includes(xType) &&
+                yType === 'quantitative'
+              ) {
+                return true;
+              } else {
+                return false;
+              }
+            } else {
+              return true;
+            }
+          })
+          .map(({ choice: kind }) => {
+            const spec = produce(props.spec, (draftSpec: GraphSpec) => {
+              draftSpec['width'] = 100;
+              draftSpec['height'] = 100;
+              if (vegaCategoricalChartList.includes(kind)) {
+                const x = draftSpec.encoding['x'];
+                const y = draftSpec.encoding['y'];
+                if (kind === 'errorband') {
+                  draftSpec.mark = { type: kind, extent: 'ci', borders: true };
+                } else if (kind === 'errorbar') {
+                  draftSpec.mark = { type: kind, extent: 'ci', ticks: true };
+                } else if (kind === 'arc') {
+                  if (x['type'] === 'quantitative') {
+                    draftSpec['encoding']['theta'] = x;
+                    draftSpec['encoding']['color'] = y;
+                  } else {
+                    draftSpec['encoding']['theta'] = y;
+                    draftSpec['encoding']['color'] = x;
+                  }
+                } else if (kind === 'boxplot') {
+                  draftSpec.mark = { type: kind, extent: 'min-max' };
+                }
+              }
+              //               else if (vegaTemporalChartList.includes(kind)) {
+
+              // draftSpec.mark = kind;
+              else {
+                draftSpec.mark = kind;
+              }
+            });
+            return (
+              <li
+                className={
+                  selectedMark === kind
+                    ? `option_${kind} selected`
+                    : `option_${kind}`
+                }
+                key={kind}
+                onClick={() => handleOnClick(spec)}
+                css={markOptionCss}
+              >
+                <VegaLite
+                  spec={spec as VisualizationSpec}
+                  data={data}
+                  actions={false}
+                />
+              </li>
+            );
+          })}
+        {/* {results.map(({ choice: kind }) => {
           let shouldSkip = false;
           const spec = produce(props.spec, (draftSpec: GraphSpec) => {
             draftSpec['width'] = 100;
@@ -133,7 +210,7 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
               />
             </li>
           );
-        })}
+        })} */}
       </ul>
     </div>
   );

--- a/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/MarkSubTab.tsx
@@ -125,7 +125,6 @@ export default function MarkSubTab(props: CustomizeSubTapProps) {
                 convertToCategoricalChartsEncoding(draftSpec, kind);
               }
             });
-            console.log(spec);
             return (
               <li
                 className={

--- a/src/components/Sidebar/Tabs/CustomizationTab/ScaleSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/ScaleSubTab.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { CustomizeSubTapProps } from './CustomizationTab';
+
+export default function ScaleSubTab(props: CustomizeSubTapProps) {
+  return <h2>Scale Tab</h2>;
+}

--- a/src/components/Sidebar/Tabs/CustomizationTab/StyleSubTab.tsx
+++ b/src/components/Sidebar/Tabs/CustomizationTab/StyleSubTab.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { CustomizeSubTapProps } from './CustomizationTab';
+
+export default function StyleSubTab(props: CustomizeSubTapProps) {
+  return <h2>Style Tab</h2>;
+}

--- a/src/components/Sidebar/Tabs/FilterScreen.tsx
+++ b/src/components/Sidebar/Tabs/FilterScreen.tsx
@@ -22,7 +22,7 @@ const screenCss = (theme: BifrostTheme) => css`
 
   h1 {
     .encoding {
-      color: ${theme.color.primary[0]};
+      color: ${theme.color.primary.dark};
     }
   }
 

--- a/src/components/ui-widgets/Pill.tsx
+++ b/src/components/ui-widgets/Pill.tsx
@@ -27,7 +27,7 @@ const pillCss = css`
 `;
 
 const activeCss = (theme: any) => css`
-  background-color: ${theme.color.primary[0]};
+  background-color: ${theme.color.primary.dark};
   color: white;
   svg {
     color: white;

--- a/src/components/ui-widgets/RangeSlider.tsx
+++ b/src/components/ui-widgets/RangeSlider.tsx
@@ -119,7 +119,7 @@ const railCss = (theme: BifrostTheme) => css`
   transform: translate(0%, -50%);
   border-radius: 7px;
   cursor: pointer;
-  background: ${theme.color.primary[2]};
+  background: ${theme.color.primary.light};
 `;
 
 const tooltipRailCss = css`
@@ -233,11 +233,11 @@ function Handle({
     height: 15px;
 
     border-radius: 50%;
-    border: 1px solid ${theme.color.primary[0]};
+    border: 1px solid ${theme.color.primary.dark};
     box-shadow: ${theme.shadow.handle};
     background-color: ${disabled
-      ? theme.color.primary[2]
-      : theme.color.primary[1]};
+      ? theme.color.primary.light
+      : theme.color.primary.standard};
   `;
 
   return (
@@ -278,7 +278,7 @@ function Track({
         transform: translate(0%, -50%);
         height: 7px;
         z-index: 1;
-        background-color: ${theme.color.primary[2]};
+        background-color: ${theme.color.primary.light};
         border-radius: 7px;
         cursor: pointer;
         left: ${source.percent}%;

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -30,7 +30,7 @@ type ModelStateName =
   | 'selected_mark'
   | 'graph_data'
   | 'suggested_graphs'
-  | 'flags';
+  | 'plot_function_args';
 
 interface ModelCallback {
   (model: WidgetModel, event: Backbone.EventHandler): void;
@@ -64,9 +64,11 @@ export type GraphSpec = VisualizationSpec & {
   data: { name: string };
 };
 
-export type Flags = {
-  columns_provided: boolean;
-  kind_provided: boolean;
+export type Args = {
+  x: string;
+  y: string;
+  color: string;
+  kind: string;
 };
 
 // HOOKS

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -56,7 +56,7 @@ export interface EncodingInfo {
 export type GraphSpec = VisualizationSpec & {
   width: number;
   height: number;
-  mark: string;
+  mark: string | Record<string, any>;
   encoding: Record<VegaEncoding, EncodingInfo>;
   transform: {
     [transformType: string]: any;

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -1,3 +1,50 @@
+import { GraphSpec } from '../hooks/bifrost-model';
+
+// preprocess graph encoding to x y encoding
+export function preprocessEncoding(spec: GraphSpec) {
+  if ('theta' in spec['encoding'] && 'color' in spec['encoding']) {
+    const theta = (spec as any)['encoding']['theta'];
+    const color = (spec as any)['encoding']['color'];
+
+    if (theta['type'] === 'quantitative') {
+      spec['encoding']['x'] = theta;
+      spec['encoding']['y'] = color;
+    } else {
+      spec['encoding']['x'] = color;
+      spec['encoding']['y'] = theta;
+    }
+    delete (spec as any)['encoding']['theta'];
+    delete (spec as any)['encoding']['color'];
+  }
+}
+
+export function convertToCategoricalChartsEncoding(
+  spec: GraphSpec,
+  kind: string
+) {
+  const x = spec.encoding['x'];
+  const y = spec.encoding['y'];
+  if (kind === 'errorband') {
+    spec.mark = { type: kind, extent: 'ci', borders: true };
+  } else if (kind === 'errorbar') {
+    spec.mark = { type: kind, extent: 'ci', ticks: true };
+  } else if (kind === 'arc') {
+    delete (spec as any)['params'];
+    delete (spec as any)['encoding']['x'];
+    delete (spec as any)['encoding']['y'];
+    if (x['type'] === 'quantitative') {
+      spec['encoding']['theta'] = x;
+      spec['encoding']['color'] = y;
+    } else {
+      spec['encoding']['theta'] = y;
+      spec['encoding']['color'] = x;
+    }
+  } else if (kind === 'boxplot') {
+    delete (spec as any)['params'];
+    spec.mark = { type: kind, extent: 'min-max' };
+  }
+}
+
 export const vegaEncodingList = [
   'x',
   'y',
@@ -128,6 +175,7 @@ export const vegaCategoricalChartList = [
   'errorband',
   'errorbar',
 ];
+
 export const vegaTemporalChartList = ['area'];
 
 export type VegaColumnType = typeof vegaColTypesList[number];

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -101,9 +101,32 @@ export const vegaParamPredicatesList = [
   'valid',
 ] as const;
 
+export const vegaChartList = [
+  'arc',
+  'area',
+  'bar',
+  'box plot',
+  'circle',
+  'error band',
+  'error bar',
+  'geoshape',
+  'image',
+  'line',
+  'point',
+  'rect',
+  'rule',
+  'square',
+  'text',
+  'tick',
+  'trail',
+];
+
 export type VegaColumnType = typeof vegaColTypesList[number];
 
 export type VegaEncoding = typeof vegaEncodingList[number];
 
 export type VegaAggregation = typeof vegaAggregationList[number];
+
 export type VegaParamPredicate = typeof vegaParamPredicatesList[number];
+
+export type VegaChart = typeof vegaChartList[number];

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -124,11 +124,11 @@ export const vegaChartList = [
 export const vegaCategoricalChartList = [
   'arc',
   'bar',
-  'box',
+  'boxplot',
   'errorband',
   'errorbar',
 ];
-export const vegaQuantitativeChartList = ['area'];
+export const vegaTemporalChartList = ['area'];
 
 export type VegaColumnType = typeof vegaColTypesList[number];
 

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -138,4 +138,4 @@ export type VegaAggregation = typeof vegaAggregationList[number];
 
 export type VegaParamPredicate = typeof vegaParamPredicatesList[number];
 
-export type VegaChart = typeof vegaChartList[number];
+export type VegaMark = typeof vegaChartList[number];

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -105,21 +105,30 @@ export const vegaChartList = [
   'arc',
   'area',
   'bar',
-  'box plot',
+  'boxplot',
   'circle',
-  'error band',
-  'error bar',
-  'geoshape',
-  'image',
+  'errorband',
+  'errorbar',
+  // 'geoshape',
+  // 'image',
   'line',
   'point',
   'rect',
-  'rule',
+  // 'rule',
   'square',
-  'text',
+  // 'text',
   'tick',
   'trail',
 ];
+
+export const vegaCategoricalChartList = [
+  'arc',
+  'bar',
+  'box',
+  'errorband',
+  'errorbar',
+];
+export const vegaQuantitativeChartList = ['area'];
 
 export type VegaColumnType = typeof vegaColTypesList[number];
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,6 +3,7 @@ const theme = {
     text: ['#000'],
     background: ['#fff', '#F6F6F6'],
     primary: ['#771C79', '#AD77AF', '#E4D2E4'],
+    onSelected: '#E4D2E4',
   },
   shadow: {
     handle: '0 0 10px #781c7932',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,8 +2,11 @@ const theme = {
   color: {
     text: ['#000'],
     background: ['#fff', '#F6F6F6'],
-    primary: ['#771C79', '#AD77AF', '#E4D2E4'],
-    onSelected: '#E4D2E4',
+    primary: {
+      dark: '#771C79',
+      standard: '#AD77AF',
+      light: '#E4D2E4',
+    },
   },
   shadow: {
     handle: '0 0 10px #781c7932',

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -39,7 +39,7 @@ export class BifrostModel extends DOMWidgetModel {
       selected_mark: '',
       graph_data: [],
       suggested_graphs: [],
-      flags: {},
+      plot_function_args: {},
     };
   }
 


### PR DESCRIPTION
## Changes
* Added the three subtabs(mark, scale, style) in customization tab.
* Added mark options that users can select in mark subtab based on the current x and y variables.
![Kapture 2021-07-08 at 17 36 30](https://user-images.githubusercontent.com/15991814/125006568-4f0a2f00-e013-11eb-9f3b-101876fe5d64.gif)
![Kapture 2021-07-12 at 16 14 43](https://user-images.githubusercontent.com/15991814/125367230-a1599180-e32c-11eb-9f4b-34dd21a97911.gif)
* Fixed the bifrost widget styling affecting the jupyterlab ui (button, text)
* Fixed the error when users give zero or one variable for the graph.
    * When the zero variable is given, it doesn't show any graph.
    * When one variable is given, it only suggests all possible charts but pie chart.

## Testing
* Plot a graph with bifrost.
* Click on the customization tab on sidebar.
* Click on mark subtab on the customization tab.
* Select one of the charts.
* See changes in the main graph.

## Future Work
* Transition from a plot to a plot with a different encoding

