### PR TITLE
Encodings Filtering in data tab

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { css, jsx } from '@emotion/react';
 import React, { useState } from 'react';
-import VariablesTab from './Tabs/VariablesTab';
+import VariablesTab from './Tabs/DataTab';
 import HistoryTab from './Tabs/HistoryTab';
 import CustomizationTab from './Tabs/CustomizationTab/CustomizationTab';
 import { GraphSpec, useModelState } from '../../hooks/bifrost-model';

--- a/src/components/Sidebar/Tabs/DataTab.tsx
+++ b/src/components/Sidebar/Tabs/DataTab.tsx
@@ -1,16 +1,16 @@
 /** @jsx jsx */
 import { css, jsx } from '@emotion/react';
 import produce from 'immer';
-
-import { PlusCircle } from 'react-feather';
 import { useEffect, useState } from 'react';
+import { Filter, PlusCircle, XCircle } from 'react-feather';
+import { EncodingInfo, GraphSpec, useModelState } from '../../../hooks/bifrost-model';
 import {
-  EncodingInfo,
-  GraphSpec,
-  useModelState,
-} from '../../../hooks/bifrost-model';
+  VegaEncoding,
+  vegaEncodingList
+  vegaMarkEncodingMap,
+  BifrostVegaMark,
+} from '../../../modules/VegaEncodings';
 import useSpecHistory from '../../../hooks/useSpecHistory';
-import { VegaEncoding, vegaEncodingList } from '../../../modules/VegaEncodings';
 import Pill from '../../ui-widgets/Pill';
 import SearchBar from '../../ui-widgets/SearchBar';
 import FilterScreen from './FilterScreen';
@@ -62,8 +62,7 @@ const variableTabCss = css`
     }
   }
 `;
-const sortedEncodingList = [...vegaEncodingList];
-sortedEncodingList.sort();
+
 export default function VariablesTab({
   clickedAxis,
   updateClickedAxis,
@@ -274,11 +273,13 @@ export default function VariablesTab({
       <ul className="encoding-list">{encodingList}</ul>
       {showEncodings && (
         <ul className="encoding-choices">
-          {sortedEncodingList.map((encoding) => (
-            <Pill onClick={() => addEncoding(encoding)}>
-              <span style={{ padding: '3px 10px' }}>{encoding}</span>
-            </Pill>
-          ))}
+          {vegaMarkEncodingMap[graphSpec.mark as BifrostVegaMark]
+            .filter((encoding) => !(encoding in graphSpec.encoding))
+            .map((encoding) => (
+              <Pill onClick={() => addEncoding(encoding as VegaEncoding)}>
+                <span style={{ padding: '3px 10px' }}>{encoding}</span>
+              </Pill>
+            ))}
         </ul>
       )}
       {activeEncoding && (

--- a/src/components/Sidebar/Tabs/DataTab.tsx
+++ b/src/components/Sidebar/Tabs/DataTab.tsx
@@ -2,11 +2,14 @@
 import { css, jsx } from '@emotion/react';
 import produce from 'immer';
 import { useEffect, useState } from 'react';
-import { Filter, PlusCircle, XCircle } from 'react-feather';
-import { EncodingInfo, GraphSpec, useModelState } from '../../../hooks/bifrost-model';
+import { PlusCircle } from 'react-feather';
+import {
+  EncodingInfo,
+  GraphSpec,
+  useModelState,
+} from '../../../hooks/bifrost-model';
 import {
   VegaEncoding,
-  vegaEncodingList
   vegaMarkEncodingMap,
   BifrostVegaMark,
 } from '../../../modules/VegaEncodings';

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -186,6 +186,29 @@ export const vegaScaleList = [
   'threshold',
 ];
 
+const bifrostVegaMark = [
+  'point',
+  'circle',
+  'sqaure',
+  'tick',
+  'line',
+  'bar',
+  'trail',
+];
+
+const minimalEncoding = ['x', 'y', 'color', 'opacity', 'size', 'facet'];
+minimalEncoding.sort();
+
+export const vegaMarkEncodingMap: Record<string, string[]> = {
+  point: minimalEncoding,
+  circle: minimalEncoding,
+  square: minimalEncoding,
+  tick: minimalEncoding,
+  line: minimalEncoding,
+  bar: minimalEncoding,
+  trail: minimalEncoding,
+};
+
 export const vegaTemporalChartList = ['area'];
 
 export type VegaColumnType = typeof vegaColTypesList[number];
@@ -197,3 +220,5 @@ export type VegaAggregation = typeof vegaAggregationList[number];
 export type VegaParamPredicate = typeof vegaParamPredicatesList[number];
 
 export type VegaMark = typeof vegaChartList[number];
+
+export type BifrostVegaMark = typeof bifrostVegaMark[number];


### PR DESCRIPTION
## Changes
* Only showed the applicable encodings for each mark in data tab
* Narrowed down the scope of graphs to `scatter, line, bar, histogram, tick`
* Organized the encodings and marks that support them [(doc)](https://docs.google.com/document/d/19Rcnm-dEhs7VMSMsk3XWusXCItKkNNa97kifkJvJhyI/edit?usp=sharing)

## Testing
* See a few possible encodings appeared when creating a new pill in data tab
