### PR TITLE
Chart Sizing

### DIFF
--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -17,7 +17,8 @@ import useSpecHistory from '../hooks/useSpecHistory';
 
 const graphCss = css`
   padding-left: 34px;
-  overflow-x: auto;
+  max-height: 500px;
+  overflow: auto;
   .vega-embed.has-actions {
     details {
       position: absolute;

--- a/src/components/VisualizationScreen.tsx
+++ b/src/components/VisualizationScreen.tsx
@@ -13,7 +13,7 @@ const bifrostWidgetCss = css`
   // Element-based styles
   //===========================================================
   display: grid;
-  grid-template-columns: 720px minmax(450px, 600px);
+  grid-template-columns: 775px minmax(450px, 600px);
   grid-template-rows: auto 500px;
   grid-template-areas: 'nav sidebar' 'graph sidebar';
   height: 100%;


### PR DESCRIPTION
Fixes #77 

# Changes
- Set the grid column width of the chart to a larger width.
- Added `overflow: auto` to the graph component so that multiple row facets will scroll

## Testing
1. Select 3 columns and map one to color
2. See spacing difference when graph is selected.