### PR TITLE
Binning

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -30,7 +30,7 @@
        "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -40,7 +40,7 @@
        "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -52,7 +52,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -77,13 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f025167ff5c14c32a93647ec4f7c211c",
+       "model_id": "17de92a7cf69452c97e13d37943ca073",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -30,7 +30,7 @@
        "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -40,7 +40,7 @@
        "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -52,7 +52,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -77,13 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "17de92a7cf69452c97e13d37943ca073",
+       "model_id": "3a6616b3dd46411db610bc69da7990f4",
        "version_major": 2,
        "version_minor": 0
       },

--- a/src/components/Onboarding/KeyboardNav.tsx
+++ b/src/components/Onboarding/KeyboardNav.tsx
@@ -123,8 +123,9 @@ export function useKeyboardNavigation({
       e.key in keyEvents && keyEvents[e.key](e);
     }
 
-    window.addEventListener('keydown', handleKeypress);
-    return () => void window.removeEventListener('keydown', handleKeypress);
+    containerRef.current?.addEventListener('keydown', handleKeypress);
+    return () =>
+      void containerRef.current?.removeEventListener('keydown', handleKeypress);
   }, [containerRef.current]);
 
   return containerRef;

--- a/src/components/Sidebar/Tabs/FilterScreen.tsx
+++ b/src/components/Sidebar/Tabs/FilterScreen.tsx
@@ -60,7 +60,7 @@ const screenCss = (theme: BifrostTheme) => css`
     display: block;
     font-size: 17px;
     font-weight: 500;
-    margin-right: 10px;
+    margin-bottom: 2px;
   }
 
   .filters {
@@ -239,7 +239,12 @@ function QuantitativeFilters(props: FilterGroupProps) {
             style={{ display: 'inline-block' }}
           />
 
-          <span className="field-label">Bin</span>
+          <span
+            className="field-label"
+            style={{ display: 'inline-block', marginLeft: 5 }}
+          >
+            Bin
+          </span>
         </label>
 
         <h2>Filter</h2>

--- a/src/components/Sidebar/Tabs/FilterScreen.tsx
+++ b/src/components/Sidebar/Tabs/FilterScreen.tsx
@@ -51,6 +51,18 @@ const screenCss = (theme: BifrostTheme) => css`
     color: ${theme.color.primary.dark};
   }
 
+  .field-wrapper {
+    display: inline-block;
+    margin: 10px;
+  }
+
+  .field-label {
+    display: block;
+    font-size: 17px;
+    font-weight: 500;
+    margin-right: 10px;
+  }
+
   .filters {
     overflow: auto;
     height: 300px;
@@ -109,6 +121,7 @@ function QuantitativeFilters(props: FilterGroupProps) {
     [graphData, currentAggregation]
   );
   const ranges = getRanges();
+  console.log(graphSpec.encoding);
 
   // Initialize a slider if one doesn't exist
   useEffect(() => {
@@ -185,28 +198,49 @@ function QuantitativeFilters(props: FilterGroupProps) {
     );
   }
 
+  function updateBin(e: React.ChangeEvent<HTMLInputElement>) {
+    setGraphSpec(
+      produce(graphSpec, (gs) => {
+        console.log(e.target.checked);
+        gs.encoding[props.encoding].bin = e.target.checked;
+      })
+    );
+  }
+
   return (
     <div className="filters">
       <div>
-        <h2>Aggregate</h2>
-        <select
-          value={currentAggregation}
-          onChange={(e) => updateAggregation(e.target.value)}
-        >
-          {['none', ...vegaAggregationList].map((aggregation) => (
-            <option value={aggregation}>{aggregation}</option>
-          ))}
-        </select>
+        <label className="field-wrapper">
+          <span className="field-label">Aggregate</span>
+          <select
+            value={currentAggregation}
+            onChange={(e) => updateAggregation(e.target.value)}
+          >
+            {['none', ...vegaAggregationList].map((aggregation) => (
+              <option value={aggregation}>{aggregation}</option>
+            ))}
+          </select>
+        </label>
+        <label className="field-wrapper">
+          <span className="field-label">Scale</span>
+          <select
+            value={currentScale}
+            onChange={(e) => updateScale(e.target.value)}
+          >
+            {vegaScaleList.map((scale) => (
+              <option value={scale}>{scale}</option>
+            ))}
+          </select>
+        </label>
+        <label className="field-wrapper">
+          <input
+            type="checkbox"
+            onChange={updateBin}
+            style={{ display: 'inline-block' }}
+          />
 
-        <h2>Scale</h2>
-        <select
-          value={currentScale}
-          onChange={(e) => updateScale(e.target.value)}
-        >
-          {vegaScaleList.map((scale) => (
-            <option value={scale}>{scale}</option>
-          ))}
-        </select>
+          <span className="field-label">Bin</span>
+        </label>
 
         <h2>Filter</h2>
       </div>

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -34,6 +34,7 @@ export interface EncodingInfo {
   scale?: {
     [scaleType: string]: any;
   };
+  bin?: boolean;
   aggregate?: string;
   axis?: {
     title?: string;


### PR DESCRIPTION
Added Binning to quantitative variables

## Changes
- Made Quantitative filter items horizontal to better utilize space
- Added binning checkbox
- Fixed keyboard navigation. Will no longer steal control from JupyterLab. Only works when you have an item in the Widget focused.

## Test

### Keyboard
- Arrow around in the cell above the widget. Verify this doesn't move the widget
- Click into the search field in the Column Selector and verify that you can now move with the arrow keys

### Binning
- Filter on a quantitative variable
- Click on binning.
- Verify that graph is effected.