### PR TITLE
DataFrame Autosave

### DIFF
--- a/bifrost_jupyter_extension/__init__.py
+++ b/bifrost_jupyter_extension/__init__.py
@@ -47,7 +47,7 @@ class BifrostAccessor:
 
         w = BifrostWidget(self._obj, column_name_map, kind, formatted_x, formatted_y, formatted_color)
         display(w)
-        return self._obj
+        return self._obj if w.output_variable else None
 
 
     def format_string(self, s):

--- a/bifrost_jupyter_extension/__init__.py
+++ b/bifrost_jupyter_extension/__init__.py
@@ -47,7 +47,7 @@ class BifrostAccessor:
 
         w = BifrostWidget(self._obj, column_name_map, kind, formatted_x, formatted_y, formatted_color)
         display(w)
-        return w.df_history[-1]
+        return self._obj
 
 
     def format_string(self, s):

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -10,13 +10,14 @@ bifrost_tracing = import_module("..", "jupyter-bifrost-tracing.bifrost_tracing.b
 df_watcher = bifrost_tracing.Watcher
 
 from traitlets.traitlets import observe
+from IPython import get_ipython
+
 
 """
 TODO: Add module docstring
 """
-import numpy as np
 from ipywidgets import DOMWidget, register
-from traitlets import Unicode, List, Int, Dict, Bool
+from traitlets import Unicode, List, Int, Dict
 from ._frontend import module_name, module_version
 from IPython.core.display import JSON, display
 import json
@@ -34,7 +35,6 @@ class BifrostWidget(DOMWidget):
     _view_module = Unicode(module_name).tag(sync=True)
     _view_module_version = Unicode(module_version).tag(sync=True)
 
-    df_history = list()
     spec_history = List([]).tag(sync=True)
     current_dataframe_index = Int(0).tag(sync=True)
     query_spec = Dict({}).tag(sync=True)
@@ -45,7 +45,8 @@ class BifrostWidget(DOMWidget):
     graph_encodings = Dict({}).tag(sync=True)
     df_variable_name = Unicode("").tag(sync=True)
     output_variable = Unicode("").tag(sync=True)
-    generate_random_dist = Int(0).tag(sync=True)
+    # Exported code that applies the graph spec changes to the original dataframe
+    df_code = Unicode("").tag(sync=True)
     df_columns = List([]).tag(sync=True)
     selected_columns = List([]).tag(sync=True)
     selected_mark = Unicode("").tag(sync=True)
@@ -54,6 +55,7 @@ class BifrostWidget(DOMWidget):
     column_types = Dict({}).tag(sync=True)
     column_name_map = Dict({}).tag(sync=True)
     graph_data_config = Dict({"maxRows": 100, "sample": False}).tag(sync=True)
+
 
     def __init__(self, df:pd.DataFrame, column_name_map: dict, kind=None, x=None, y=None, color=None, **kwargs):
         super().__init__(**kwargs)
@@ -71,7 +73,7 @@ class BifrostWidget(DOMWidget):
         self.set_trait("column_types", column_types)
         self.set_trait("column_name_map", column_name_map)
 
-        df.columns = column_name_map.values();
+        df.columns = column_name_map.values()
         if df_watcher.plot_output: self.set_trait("output_variable", df_watcher.plot_output)
         if df_watcher.bifrost_input: self.set_trait("df_variable_name", df_watcher.bifrost_input)
         
@@ -81,18 +83,12 @@ class BifrostWidget(DOMWidget):
         # Vega spec is updated from the frontend. To track history, respond to these changes here.
         pass
 
+    @observe("df_code")
+    def update_output_dataframe(self, changes):
+        code = changes["new"]
+        print(code)
+        get_ipython().run_cell(code).result
 
-    @observe("generate_random_dist")
-    def create_random_distribution(self, _):
-        graph_kinds = ['tick', 'bar', 'line', 'point']
-        kind = random.choice(graph_kinds)
-        dist = np.random.uniform(0,1, (random.randint(25,50), 4))
-        df = pd.DataFrame(dist, columns=["foo", "bar", "something", "else"])
-        self.df_history.append(df)
-        graph_info = self.create_graph_data(self.df_history[-1], kind)
-        self.set_trait("df_columns", list(df.columns))
-        self.set_trait("graph_spec", graph_info["spec"])
-        self.set_trait("graph_data", graph_info["data"])
 
     @observe("graph_data_config")
     def update_dataset(self, changes):

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -86,7 +86,6 @@ class BifrostWidget(DOMWidget):
     @observe("df_code")
     def update_output_dataframe(self, changes):
         code = changes["new"]
-        print(code)
         get_ipython().run_cell(code).result
 
 

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -86,7 +86,8 @@ class BifrostWidget(DOMWidget):
     @observe("df_code")
     def update_output_dataframe(self, changes):
         code = changes["new"]
-        get_ipython().run_cell(code).result
+        if self.output_variable != "":
+            get_ipython().run_cell(code).result
 
 
     @observe("graph_data_config")

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -105,16 +105,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iris_df = iris_df[(iris_df['class'].isin([\"iris_versicolour\",\"iris_virginica\"]))&(iris_df['petal length (cm)'] >= 2.8355468749999995) & (iris_df['petal length (cm)'] <= 6.055546875)]\n"
+    "titanic_df = titanic_df[(titanic_df['age'] >= 22.620000000000005) & (titanic_df['age'] <= 80)&(titanic_df['class'].isin([\"First\",\"Second\"]))]\n",
+    "group_fields = [\"class\"]\n",
+    "titanic_df = titanic_df.join(titanic_df.groupby(group_fields).agg(\"mean\")[\"age\"], on=group_fields, rsuffix=\" mean\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['First', 'Second'], dtype=object)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "titanic_df[\"age\"].isna()"
+    "res[\"class\"].unique()"
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -105,29 +105,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "titanic_df = titanic_df[(titanic_df['age'] >= 22.620000000000005) & (titanic_df['age'] <= 80)&(titanic_df['class'].isin([\"First\",\"Second\"]))]\n",
+    "res = titanic_df[(0['age'] >= 44.32000000000001) & (0['age'] <= 80)]\n",
     "group_fields = [\"class\"]\n",
-    "titanic_df = titanic_df.join(titanic_df.groupby(group_fields).agg(\"mean\")[\"age\"], on=group_fields, rsuffix=\" mean\")"
+    "res = res.join(res.groupby(group_fields).agg(\"max\")[\"age\"], on=group_fields, rsuffix=\" max\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array(['First', 'Second'], dtype=object)"
+       "30.0"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "res[\"class\"].unique()"
+    "res[\"age\"].min()"
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -30,7 +30,7 @@
        "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -40,7 +40,7 @@
        "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -52,7 +52,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -77,13 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df2e0d53a6904d2cbd4f5431be5a6518",
+       "model_id": "790e8d2f2271435a91da0eb3257ddc69",
        "version_major": 2,
        "version_minor": 0
       },
@@ -112,20 +112,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "30.0"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "res[\"age\"].min()"
    ]
@@ -168,7 +157,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -182,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,10 +4,8 @@ import React, { useState } from 'react';
 import VariablesTab from './Tabs/DataTab';
 import HistoryTab from './Tabs/HistoryTab';
 import MarkTab from './Tabs/MarkTab';
-import { GraphSpec, useModelState } from '../../hooks/bifrost-model';
-import VegaPandasTranslator from '../../modules/VegaPandasTranslator';
+import { useModelState } from '../../hooks/bifrost-model';
 import { VegaEncoding } from '../../modules/VegaEncodings';
-import produce from 'immer';
 import { CSSTransitionGroup } from 'react-transition-group';
 import theme from '../../theme';
 
@@ -170,35 +168,10 @@ const actionBarCss = css`
 `;
 
 function ActionBar() {
-  const spec = useModelState('graph_spec')[0];
-  const columnNameMap = useModelState('column_name_map')[0];
-  const [dataframeName] = useModelState('df_variable_name');
+  const dfCode = useModelState('df_code')[0];
 
   function exportCode() {
-    // convert formatted columns to original
-    const updateField = (filter: { field: string }) =>
-      (filter.field = columnNameMap[filter.field]);
-
-    const revertedSpec = produce(spec, (gs: GraphSpec) => {
-      const compounds = ['and', 'or', 'not'];
-      gs.transform.forEach(({ filter }) => {
-        const filterKeys = Object.keys(filter);
-        const compoundOp = compounds.find((c) =>
-          filterKeys.find((k) => c === k)
-        );
-        if (compoundOp) {
-          filter[compoundOp].forEach(updateField);
-        } else {
-          updateField(filter);
-        }
-      });
-    });
-
-    const translator = new VegaPandasTranslator();
-    const query = translator
-      .convertSpecToCode(revertedSpec)
-      .replace(/\$df/g, dataframeName || 'df');
-    navigator.clipboard.writeText(query);
+    navigator.clipboard.writeText(dfCode);
   }
 
   return (

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -176,16 +176,22 @@ function ActionBar() {
 
   function exportCode() {
     // convert formatted columns to original
+    const updateField = (filter: { field: string }) =>
+      (filter.field = columnNameMap[filter.field]);
+
     const revertedSpec = produce(spec, (gs: GraphSpec) => {
-      Object.keys(gs.encoding).forEach((channel) => {
-        gs.encoding[channel as VegaEncoding].field =
-          columnNameMap[gs.encoding[channel as VegaEncoding].field];
+      const compounds = ['and', 'or', 'not'];
+      gs.transform.forEach(({ filter }) => {
+        const filterKeys = Object.keys(filter);
+        const compoundOp = compounds.find((c) =>
+          filterKeys.find((k) => c === k)
+        );
+        if (compoundOp) {
+          filter[compoundOp].forEach(updateField);
+        } else {
+          updateField(filter);
+        }
       });
-      gs.transform.forEach((obj) =>
-        obj['filter']['or'].forEach((el: any) => {
-          el.field = columnNameMap[el.field];
-        })
-      );
     });
 
     const translator = new VegaPandasTranslator();

--- a/src/hooks/useSpecHistory.ts
+++ b/src/hooks/useSpecHistory.ts
@@ -21,6 +21,7 @@ export default function useSpecHistory(
   const setDfCode = useModelState('df_code')[1];
   const [columnMap] = useModelState('column_name_map');
   const [outputVar] = useModelState('output_variable');
+  const [inputVar] = useModelState('df_variable_name');
   const [originalSpec, setOriginalSpec] = useState(graphSpec);
   const saveRef = useRef<(spec?: GraphSpec) => void>(save);
 
@@ -50,7 +51,7 @@ export default function useSpecHistory(
     setOpHistory(newHist);
     setIndex(newHist.length - 1);
     setOriginalSpec(spec);
-    setDfCode(updateDfCode(outputVar, spec, columnMap));
+    setDfCode(updateDfCode(spec, inputVar, outputVar, columnMap));
   }
 
   saveRef.current = save;
@@ -58,15 +59,10 @@ export default function useSpecHistory(
   return save;
 }
 
-/**
- *
- * @param dataframeName Name of output dataframe ex. foo in `foo=df.bifrost.plot()`
- * @param spec Updated graph spec.
- * @param columnNameMap Mapping from Draco-compliant column names to originals.
- */
 function updateDfCode(
-  dataframeName: string,
   spec: GraphSpec,
+  inputDfName: string,
+  outputDfName: string,
   columnNameMap: Record<string, string>
 ): string {
   const updateField = (filter: { field: string }) =>
@@ -86,7 +82,5 @@ function updateDfCode(
   });
 
   const translator = new VegaPandasTranslator();
-  return translator
-    .convertSpecToCode(revertedSpec)
-    .replace(/\$df/g, dataframeName || 'df');
+  return translator.convertSpecToCode(revertedSpec, inputDfName, outputDfName);
 }

--- a/src/hooks/useSpecHistory.ts
+++ b/src/hooks/useSpecHistory.ts
@@ -1,4 +1,6 @@
+import produce from 'immer';
 import { useEffect, useRef, useState } from 'react';
+import VegaPandasTranslator from '../modules/VegaPandasTranslator';
 import { GraphSpec, useModelState } from './bifrost-model';
 
 interface SpecHistoryOptions {
@@ -16,6 +18,9 @@ export default function useSpecHistory(
   const [opHistory, setOpHistory] = useModelState('spec_history');
   const graphSpec = useModelState('graph_spec')[0];
   const [index, setIndex] = useModelState('current_dataframe_index');
+  const setDfCode = useModelState('df_code')[1];
+  const [columnMap] = useModelState('column_name_map');
+  const [outputVar] = useModelState('output_variable');
   const [originalSpec, setOriginalSpec] = useState(graphSpec);
   const saveRef = useRef<(spec?: GraphSpec) => void>(save);
 
@@ -45,9 +50,43 @@ export default function useSpecHistory(
     setOpHistory(newHist);
     setIndex(newHist.length - 1);
     setOriginalSpec(spec);
+    setDfCode(updateDfCode(outputVar, spec, columnMap));
   }
 
   saveRef.current = save;
 
   return save;
+}
+
+/**
+ *
+ * @param dataframeName Name of output dataframe ex. foo in `foo=df.bifrost.plot()`
+ * @param spec Updated graph spec.
+ * @param columnNameMap Mapping from Draco-compliant column names to originals.
+ */
+function updateDfCode(
+  dataframeName: string,
+  spec: GraphSpec,
+  columnNameMap: Record<string, string>
+): string {
+  const updateField = (filter: { field: string }) =>
+    (filter.field = columnNameMap[filter.field]);
+
+  const revertedSpec = produce(spec, (gs: GraphSpec) => {
+    const compounds = ['and', 'or', 'not'];
+    gs.transform.forEach(({ filter }) => {
+      const filterKeys = Object.keys(filter);
+      const compoundOp = compounds.find((c) => filterKeys.find((k) => c === k));
+      if (compoundOp) {
+        filter[compoundOp].forEach(updateField);
+      } else {
+        updateField(filter);
+      }
+    });
+  });
+
+  const translator = new VegaPandasTranslator();
+  return translator
+    .convertSpecToCode(revertedSpec)
+    .replace(/\$df/g, dataframeName || 'df');
 }

--- a/src/modules/VegaPandasTranslator.ts
+++ b/src/modules/VegaPandasTranslator.ts
@@ -8,51 +8,53 @@ import { GraphSpec, EncodingInfo } from '../hooks/bifrost-model';
 const filterTypes = new Set<string>(vegaParamPredicatesList);
 
 interface AggFunc {
-  (encoding: EncodingInfo): string;
+  (encoding: EncodingInfo, dfName: string): string;
 }
 const vegaAggToPd: { [vegaAgg: string]: string | AggFunc } = {
   count: 'count',
-  valid: (encoding) =>
-    `$df.join($df.dropna().groupby(group_fields).count()["${encoding.field}"], on=group_fields, rsuffix=" valid count")`,
-  missing: (encoding) =>
-    `$df.join($df.groupby(group_fields)["${encoding.field}"].apply(lambda x: x.isnull().sum()), on=group_fields, rsuffix=" missing")`,
-  distinct: (encoding) =>
-    `$df.join($df.dropna().groupby(group_fields).unique()["${encoding.field}"], on=group_fields, rsuffix=" distinct")`,
+  valid: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.dropna().groupby(group_fields).count()["${encoding.field}"], on=group_fields, rsuffix=" valid count")`,
+  missing: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.groupby(group_fields)["${encoding.field}"].apply(lambda x: x.isnull().sum()), on=group_fields, rsuffix=" missing")`,
+  distinct: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.dropna().groupby(group_fields).unique()["${encoding.field}"], on=group_fields, rsuffix=" distinct")`,
   sum: 'sum',
   product: 'prod',
   mean: 'mean',
   variance: 'var',
-  variancep: (encoding) =>
-    `$df.join($df.groupby(group_fields).var(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population variance")`,
+  variancep: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.groupby(group_fields).var(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population variance")`,
   stdev: 'std',
-  stdevp: (encoding) =>
-    `$df.join($df.groupby(group_fields).std(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population std")`,
-  stderr: (encoding) =>
-    `$df.join($df.groupby(group_fields).sem()["${encoding.field}"], on=group_fields, rsuffix=" stderr")`,
+  stdevp: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.groupby(group_fields).std(ddof=0)["${encoding.field}"], on=group_fields, rsuffix=" population std")`,
+  stderr: (encoding, dfName) =>
+    `${dfName}.join(${dfName}.groupby(group_fields).sem()["${encoding.field}"], on=group_fields, rsuffix=" stderr")`,
   median: 'median',
   min: 'min',
   max: 'max',
 };
 
 export default class VegaPandasTranslator {
-  private getQueryFromFilter(filterConfig: any): string {
+  private getQueryFromFilter(filterConfig: any, dfName: string): string {
     return Object.keys(filterConfig)
       .filter((key) => filterTypes.has(key))
       .map((filterType) => {
         let query: string;
         switch (filterType as VegaParamPredicate) {
           case 'gte':
-            query = `($df['${filterConfig.field}'] >= ${filterConfig.gte})`;
+            query = `(${dfName}['${filterConfig.field}'] >= ${filterConfig.gte})`;
             break;
           case 'lte':
-            query = `($df['${filterConfig.field}'] <= ${filterConfig.lte})`;
+            query = `(${dfName}['${filterConfig.field}'] <= ${filterConfig.lte})`;
             break;
           case 'range':
             // Expects number range like {range: [0, 5]}.
-            query = `($df['${filterConfig.field}'] >= ${filterConfig.range[0]}) & ($df['${filterConfig.field}'] <= ${filterConfig.range[1]})`;
+            query = `(${dfName}['${filterConfig.field}'] >= ${filterConfig.range[0]}) & (${dfName}['${filterConfig.field}'] <= ${filterConfig.range[1]})`;
             break;
           case 'oneOf':
-            query = `($df['${filterConfig.field}'].isin([${filterConfig.oneOf
+            query = `(${dfName}['${
+              filterConfig.field
+            }'].isin([${filterConfig.oneOf
               .map((str: string) => `"${str}"`)
               .toString()}]))`;
             break;
@@ -66,7 +68,10 @@ export default class VegaPandasTranslator {
       .join('&');
   }
 
-  private getFilterFromTransform(transform: GraphSpec['transform']) {
+  private getFilterFromTransform(
+    transform: GraphSpec['transform'],
+    dfName: string
+  ) {
     return transform
       .map((t) => {
         const compoundOperator =
@@ -74,8 +79,8 @@ export default class VegaPandasTranslator {
         if (compoundOperator) {
           // Handle compound query ex. "and", "or", "not"
           const connector = compoundOperator === 'or' ? '|' : '&';
-          const compFilters = t.filter[compoundOperator].map(
-            this.getQueryFromFilter
+          const compFilters = t.filter[compoundOperator].map((filter: any) =>
+            this.getQueryFromFilter(filter, dfName)
           );
           let query = compFilters.join(connector);
           if (compFilters.length > 1) {
@@ -83,13 +88,13 @@ export default class VegaPandasTranslator {
           }
           return query;
         } else {
-          return this.getQueryFromFilter(t.filter);
+          return this.getQueryFromFilter(t.filter, dfName);
         }
       })
       .join('&');
   }
 
-  private getAggregations(encodings: GraphSpec['encoding']) {
+  private getAggregations(encodings: GraphSpec['encoding'], dfName: string) {
     const encodingVals = Object.values(encodings);
     return encodingVals
       .filter((encoding) => 'aggregate' in encoding)
@@ -102,26 +107,37 @@ export default class VegaPandasTranslator {
         if (typeof agg === 'string') {
           return [
             pandasGroupFields,
-            `$df = $df.join($df.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`,
+            `${dfName} = ${dfName}.join(${dfName}.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`,
           ].join('\n');
         } else {
-          return [pandasGroupFields, `$df = ${agg(encoding)}`].join('\n');
+          return [
+            pandasGroupFields,
+            `${dfName} = ${agg(encoding, dfName)}`,
+          ].join('\n');
         }
       })
       .join('\n');
   }
 
-  convertSpecToCode(spec: GraphSpec) {
+  /**
+   *
+   * @param spec Graph spec to convert to pandas code
+   * @param inputDf Name of the DataFrame which is the target of the Bifrost Plot
+   * @param outputDf Name of the DataFrame which is assigned to the output of bifrost.plot()
+   * @returns Pandas code that applies the spec changes to the inputDf.
+   */
+  convertSpecToCode(spec: GraphSpec, inputDf = '', outputDf = '') {
     // Filters
-    const filterQuery = this.getFilterFromTransform(spec.transform);
-    const filteredDs = filterQuery.length ? `$df = $df[${filterQuery}]` : '';
+    const filterQuery = this.getFilterFromTransform(spec.transform, inputDf);
+    const filteredDs = filterQuery.length
+      ? `${outputDf} = ${inputDf}[${filterQuery}]`
+      : '';
     // Aggregators
-    const aggregations = this.getAggregations(spec.encoding);
-    // Check
-    const code = [filteredDs, aggregations].join('\n');
+    const aggregations = this.getAggregations(spec.encoding, outputDf);
 
+    const code = [filteredDs, aggregations].join('\n');
     const isAlphaNum = /\w/;
 
-    return isAlphaNum.test(code) ? code : '$df';
+    return isAlphaNum.test(code) ? code : inputDf;
   }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -33,7 +33,6 @@ const bifrostModelPropDefaults = {
   graph_spec: {} as GraphSpec,
   query_spec: {} as QuerySpec,
   graph_encodings: {},
-  generate_random_dist: 0,
   df_columns: [] as string[],
   selected_data: ['', {}] as SelectionData,
   selected_columns: [] as string[],
@@ -46,6 +45,7 @@ const bifrostModelPropDefaults = {
   column_types: {} as Record<EncodingInfo['field'], EncodingInfo['type']>,
   column_name_map: {} as Record<string, string>,
   graph_data_config: { maxRows: 100, sample: false } as GraphDataConfig,
+  df_code: '$df',
 };
 
 export type ModelState = typeof bifrostModelPropDefaults;


### PR DESCRIPTION
Save data to the output dataframe every time the history is updated.

## Changes
- Added new `df_code` variable that stores the code output on spec history save.
- Fixed issue with reverting the field names which didn't work with non-compound values.
- Sets the output variable to the result of `df_code` on spec updates.

## Test
1. Open Bifrost and filter a quantitative field.
2. Print out the `max()` and `min()`  value of that field in `res` before and after the filtering.
3. Do the same with categorical but use `unique()` to test.