### PR TITLE
Performance Sampling

### DIFF
--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -53,7 +53,7 @@ class BifrostWidget(DOMWidget):
     suggested_graphs = List([]).tag(sync=True)
     column_types = Dict({}).tag(sync=True)
     column_name_map = Dict({}).tag(sync=True)
-    graph_data_config = Dict({"maxRows": 1, "sample": False}).tag(sync=True)
+    graph_data_config = Dict({"maxRows": 100, "sample": False}).tag(sync=True)
 
     def __init__(self, df:pd.DataFrame, column_name_map: dict, kind=None, x=None, y=None, color=None, **kwargs):
         super().__init__(**kwargs)
@@ -97,7 +97,7 @@ class BifrostWidget(DOMWidget):
     @observe("graph_data_config")
     def update_dataset(self, changes):
         config = changes["new"]
-        if changes["old"]["sample"] == config["sample"]:
+        if changes["old"]["sample"] == config["sample"] or config["maxRows"] >= len(self.df_history[-1]):
             return
         if config["sample"]:
             self.set_trait("graph_data", self.get_data(self.df_history[-1], config["maxRows"]))

--- a/bifrost_jupyter_extension/bifrost.py
+++ b/bifrost_jupyter_extension/bifrost.py
@@ -58,7 +58,7 @@ class BifrostWidget(DOMWidget):
     def __init__(self, df:pd.DataFrame, column_name_map: dict, kind=None, x=None, y=None, color=None, **kwargs):
         super().__init__(**kwargs)
         self.df_history.append(df)
-        data = self.get_data(df, 10)
+        data = self.get_data(df, self.graph_data_config["maxRows"])
         column_types = self.get_column_types(df)
         graph_info = self.create_graph_data(df, data, column_types, kind=kind, x=x, y=y, color=color)
 

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,6 +125,15 @@
    "source": [
     "x = [\"zap\", \"1,2\", \"age\", \"better\"]\n",
     "sorted(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "titanic_df.sample(4)"
    ]
   },
   {

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -141,12 +141,21 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "len(titanic_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -160,7 +169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/src/components/Onboarding/OnboardingWidget.tsx
+++ b/src/components/Onboarding/OnboardingWidget.tsx
@@ -4,8 +4,9 @@ import { jsx, css } from '@emotion/react';
 import ChartChooser from './ChartChooser';
 import ColumnSelectorSidebar from './ColumnSelectorSidebar';
 
-import { Args } from '../../hooks/bifrost-model';
+import { Args, useModelState } from '../../hooks/bifrost-model';
 import { useKeyboardNavigation } from './KeyboardNav';
+import { useEffect } from 'react';
 
 interface OnboardingWidgetProps {
   onOnboarded: () => void;
@@ -29,6 +30,14 @@ export default function OnboardingWidget(props: OnboardingWidgetProps) {
   const ref = useKeyboardNavigation({
     jumpTo: { ArrowLeft: 'search', ArrowRight: 'chart0' },
   });
+
+  const [graphConfig, setGraphConfig] = useModelState('graph_data_config');
+
+  // Handle downsampling with multiple charts
+  useEffect(() => {
+    setGraphConfig({ ...graphConfig, sample: true });
+    return () => void setGraphConfig({ ...graphConfig, sample: false });
+  }, []);
 
   return (
     <article className="OnboardingWidget" css={onboardingWidgetCss} ref={ref}>

--- a/src/components/Onboarding/OnboardingWidget.tsx
+++ b/src/components/Onboarding/OnboardingWidget.tsx
@@ -36,7 +36,9 @@ export default function OnboardingWidget(props: OnboardingWidgetProps) {
   // Handle downsampling with multiple charts
   useEffect(() => {
     setGraphConfig({ ...graphConfig, sample: true });
-    return () => void setGraphConfig({ ...graphConfig, sample: false });
+    return () => {
+      setGraphConfig({ ...graphConfig, sample: false });
+    };
   }, []);
 
   return (

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -173,6 +173,7 @@ function ActionBar() {
   const spec = useModelState('graph_spec')[0];
   const columnNameMap = useModelState('column_name_map')[0];
   const [dataframeName] = useModelState('df_variable_name');
+  const [dataConfig, setDataConfig] = useModelState('graph_data_config');
 
   function exportCode() {
     // convert formatted columns to original
@@ -200,6 +201,18 @@ function ActionBar() {
       <ul>
         <li>
           <button onClick={exportCode}>Export Code</button>
+        </li>
+        <li>
+          <button
+            onClick={() =>
+              setDataConfig({
+                sample: !dataConfig.sample,
+                maxRows: dataConfig.maxRows + 1,
+              })
+            }
+          >
+            Change Config
+          </button>
         </li>
       </ul>
     </nav>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -173,7 +173,6 @@ function ActionBar() {
   const spec = useModelState('graph_spec')[0];
   const columnNameMap = useModelState('column_name_map')[0];
   const [dataframeName] = useModelState('df_variable_name');
-  const [dataConfig, setDataConfig] = useModelState('graph_data_config');
 
   function exportCode() {
     // convert formatted columns to original
@@ -201,18 +200,6 @@ function ActionBar() {
       <ul>
         <li>
           <button onClick={exportCode}>Export Code</button>
-        </li>
-        <li>
-          <button
-            onClick={() =>
-              setDataConfig({
-                sample: !dataConfig.sample,
-                maxRows: dataConfig.maxRows + 1,
-              })
-            }
-          >
-            Change Config
-          </button>
         </li>
       </ul>
     </nav>

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -64,6 +64,12 @@ export type SelectionData = [
   string,
   { [field: string]: [number, number] | string[] }
 ];
+
+export type GraphDataConfig = {
+  maxRows: number;
+  sample: boolean;
+};
+
 // HOOKS
 //============================================================================================
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -45,7 +45,7 @@ const bifrostModelPropDefaults = {
   plot_function_args: {} as Args,
   column_types: {} as Record<EncodingInfo['field'], EncodingInfo['type']>,
   column_name_map: {} as Record<string, string>,
-  graph_data_config: { maxRows: 1000, sample: false } as GraphDataConfig,
+  graph_data_config: { maxRows: 100, sample: false } as GraphDataConfig,
 };
 
 export type ModelState = typeof bifrostModelPropDefaults;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -17,6 +17,7 @@ import {
   Args,
   EncodingInfo,
   SelectionData,
+  GraphDataConfig,
 } from './hooks/bifrost-model';
 
 import { MODULE_NAME, MODULE_VERSION } from './version';
@@ -44,6 +45,7 @@ const bifrostModelPropDefaults = {
   plot_function_args: {} as Args,
   column_types: {} as Record<EncodingInfo['field'], EncodingInfo['type']>,
   column_name_map: {} as Record<string, string>,
+  graph_data_config: { maxRows: 1000, sample: false } as GraphDataConfig,
 };
 
 export type ModelState = typeof bifrostModelPropDefaults;


### PR DESCRIPTION
Added sampling to the Onboarding Screen.

## Changes
- Added `graph_data_config` object that controls sampling on the `graph_data` object.
- Added automatic sampling when the Onboarding screen mounts and dismounts.

## Testing
- You could add a print statement to `update_dataset` to see how the graph data gets updated
- Or visually confirm that clicking the chart adds more data.