### PR TITLE
Move export code

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import { jsx, css } from '@emotion/react';
 import { ArrowLeft, Code, HelpCircle } from 'react-feather';
+import Tooltip from './Tooltip';
 
 const graphNavCss = css`
   ul {
@@ -33,9 +34,11 @@ export default function NavBar(props: NavBarProps) {
           </button>
         </li>
         <li>
-          <button className="wrapper" onClick={props.onExportCodeRequested}>
-            <Code />
-          </button>
+          <Tooltip message={'Export Code'} position="right">
+            <button className="wrapper" onClick={props.onExportCodeRequested}>
+              <Code />
+            </button>
+          </Tooltip>
         </li>
         <li>
           <button className="wrapper" onClick={props.onHelpRequested}>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,7 +1,7 @@
 /**@jsx jsx */
 
 import { jsx, css } from '@emotion/react';
-import { ArrowLeft, HelpCircle } from 'react-feather';
+import { ArrowLeft, Code, HelpCircle } from 'react-feather';
 
 const graphNavCss = css`
   ul {
@@ -20,6 +20,7 @@ const graphNavCss = css`
 interface NavBarProps {
   onBack?(): void;
   onHelpRequested?(): void;
+  onExportCodeRequested?(): void;
 }
 
 export default function NavBar(props: NavBarProps) {
@@ -29,6 +30,11 @@ export default function NavBar(props: NavBarProps) {
         <li>
           <button className="wrapper" onClick={props.onBack}>
             <ArrowLeft />
+          </button>
+        </li>
+        <li>
+          <button className="wrapper" onClick={props.onExportCodeRequested}>
+            <Code />
           </button>
         </li>
         <li>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 import EditTab from './Tabs/EditTab';
 import HistoryTab from './Tabs/HistoryTab';
 import NearbyTab from './Tabs/NearbyTab';
-import { useModelState } from '../../hooks/bifrost-model';
 import { VegaEncoding } from '../../modules/VegaEncodings';
 import { CSSTransitionGroup } from 'react-transition-group';
 import theme, { BifrostTheme } from '../../theme';
@@ -39,8 +38,8 @@ const sidebarCss = css`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 500px;
-  height: 100%;
+  max-width: 330px;
+  height: 97%;
   min-height: 400px;
   border-radius: 2.5% 2.5% 0 0;
   box-shadow: ${theme.shadow.handle};
@@ -94,7 +93,6 @@ export default function Sidebar(props: {
             updateClickedAxis={props.updateClickedAxis}
           />
         </div>
-        <ActionBar />
       </aside>
     </CSSTransitionGroup>
   );
@@ -149,39 +147,6 @@ function TabBar(props: TabBarProps) {
             {tab}
           </li>
         ))}
-      </ul>
-    </nav>
-  );
-}
-
-const actionBarCss = css`
-  ul {
-    display: flex;
-    justify-content: center;
-    border-top: none;
-    list-style: none;
-    margin: 0;
-    padding: 12px;
-    box-shadow: 0 0 20px #00000017;
-  }
-  li {
-    margin: 0 10px;
-  }
-`;
-
-function ActionBar() {
-  const dfCode = useModelState('df_code')[0];
-
-  function exportCode() {
-    navigator.clipboard.writeText(dfCode);
-  }
-
-  return (
-    <nav className="action-bar" css={actionBarCss}>
-      <ul>
-        <li>
-          <button onClick={exportCode}>Export Code</button>
-        </li>
       </ul>
     </nav>
   );

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -50,7 +50,10 @@ const sidebarCss = css`
     border-top: 2px solid #e4e4e4;
     padding: 10px;
     padding-bottom: 0;
-    height: 430px;
+    height: 100%;
+    display: flex;
+    justify-content: column;
+    overflow: hidden;
   }
 `;
 const tabMapping: {

--- a/src/components/Sidebar/Tabs/EditTab.tsx
+++ b/src/components/Sidebar/Tabs/EditTab.tsx
@@ -38,6 +38,7 @@ import AddPillScreen from './AddPillScreen';
 const variableTabCss = css`
   position: relative;
   width: 100%;
+  overflow: scroll;
 
   h3 {
     .data-section,

--- a/src/components/VisualizationScreen.tsx
+++ b/src/components/VisualizationScreen.tsx
@@ -9,6 +9,7 @@ import { VegaEncoding } from '../modules/VegaEncodings';
 import SideBarCollapsibleButtonIcon from '../assets/icons/SideBarCollapsibleButtonIcon';
 import theme from '../theme';
 import HelpScreen from './HelpScreen/HelpScreen';
+import { useModelState } from '../hooks/bifrost-model';
 
 const bifrostWidgetCss = css`
   // Element-based styles
@@ -51,6 +52,7 @@ export default function VisualizationScreen({
   const [clickedAxis, setClickedAxis] = useState<VegaEncoding | ''>('');
   const [sideBarOpen, setSideBarOpen] = useState<boolean>(true);
   const [showHelpScreen, setShowHelpScreen] = useState(false);
+  const [dfCode] = useModelState('df_code');
 
   function updateClickedAxis(encoding: VegaEncoding | ''): void {
     setClickedAxis(encoding);
@@ -58,6 +60,10 @@ export default function VisualizationScreen({
 
   function onClickCollapsibleButton() {
     setSideBarOpen(!sideBarOpen);
+  }
+
+  function onExportCodeRequested() {
+    navigator.clipboard.writeText(dfCode);
   }
 
   return (
@@ -68,6 +74,7 @@ export default function VisualizationScreen({
             <NavBar
               onBack={onPrevious}
               onHelpRequested={() => setShowHelpScreen(true)}
+              onExportCodeRequested={onExportCodeRequested}
             />
             <div
               className={`side-bar-collapsible-button${

--- a/src/components/VisualizationScreen.tsx
+++ b/src/components/VisualizationScreen.tsx
@@ -15,7 +15,7 @@ const bifrostWidgetCss = css`
   // Element-based styles
   //===========================================================
   display: grid;
-  grid-template-columns: minmax(720px, min-content) minmax(max-content, auto);
+  grid-template-columns: minmax(600px, min-content) minmax(max-content, auto);
   grid-template-rows: 40px auto;
   grid-template-areas: 'nav sidebar' 'graph sidebar';
   height: 100%;


### PR DESCRIPTION
## Changes
![Screen Shot 2021-08-18 at 11 12 49 AM](https://user-images.githubusercontent.com/15991814/129950530-af7aee17-f1b4-482c-9402-bdd937390b5f.png)

* Placed export code button next to the back arrow in nav bar
* Changed the sidebar size to 330px as in @angelachawla 's mockup
* Made graph size to 600px to prevent the sidebar from getting cut when the filebrowser is open