### PR TITLE
Nearby Highlights

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -9,9 +9,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "args=[]\n"
+     ]
+    }
+   ],
    "source": [
     "from jupyter_bifrost import Chart\n",
     "import pandas as pd\n",
@@ -21,40 +29,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Index(['foo', 'y', 'bar', 'baz', 'something', 'else'], dtype='object')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Index(['Name', 'Job', 'Years Worked For Jupyter'], dtype='object')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Index(['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)',\n",
-       "       'petal width (cm)', 'class'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "args=['iris_df.class']\n"
+     ]
     }
    ],
    "source": [
@@ -77,22 +60,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "args=[]\n"
+     ]
+    }
+   ],
    "source": [
     "chart = Chart('https://raw.githubusercontent.com/mwaskom/seaborn-data/master/titanic.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a573d1a52c14de99a4d0365f8c82238",
+       "model_id": "65e198cca1d24b8bb9bb3b4393899ece",
        "version_major": 2,
        "version_minor": 0
       },
@@ -375,9 +366,16 @@
        "[891 rows x 15 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "args=[]\n"
+     ]
     }
    ],
    "source": [
@@ -401,7 +399,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -38,6 +38,10 @@ export interface EncodingInfo {
   aggregate?: string;
   axis?: {
     title?: string;
+    titleColor?: string;
+  };
+  legend?: {
+    titleColor?: string;
   };
 }
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/33008436/129958955-8a14297a-d344-4dd0-bba4-54675e2be489.mov

## Changes
- Added red highlights on axes and legends where the encoding value differs between the current and recommended specs.
- Eliminated the first recommendation, since it was always identical to the current graph
- Split the chart recommendation function into separate functional blocks.
- Added title to the Nearby Tab
- Fixed sizing issues with Nearby tab.

## Testing
- Scroll through the nearby tab and verify that any encoding differences are highlighted in red.
- Click on graph in the Nearby recommendations and verify that the highlights do not carry over to the main plot.