### PR TITLE
Mark Icon Filters

### DIFF
--- a/src/assets/icons/chartIcons/ChartIcons.ts
+++ b/src/assets/icons/chartIcons/ChartIcons.ts
@@ -8,8 +8,9 @@ import BoxPlotChartIcon from './BoxPlotChartIcon';
 import ErrorBandChartIcon from './ErrorBandChartIcon';
 // import SquareChartIcon from './SquareChartIcon';
 import ErrorBarChartIcon from './ErrorBarChartIcon';
+import { VegaMark } from '../../../modules/VegaEncodings';
 
-export const chartIcons = [
+export const chartIcons: { icon: typeof BarChartIcon; mark: VegaMark }[] = [
   { icon: BarChartIcon, mark: 'bar' },
   { icon: ScatterChartIcon, mark: 'point' },
   { icon: LineChartIcon, mark: 'line' },

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -35,6 +35,14 @@ const globalStyles = (theme: any) => css`
         transform: scale(0.95);
       }
 
+      &:active:disabled {
+        transform: scale(1);
+      }
+      &:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+
       &.wrapper {
         border: none;
         background: transparent;

--- a/src/components/Sidebar/Tabs/EditTab.tsx
+++ b/src/components/Sidebar/Tabs/EditTab.tsx
@@ -695,23 +695,33 @@ function validateMarkChange(mark: VegaMark, spec: GraphSpec): boolean {
     } else return false;
   };
 
+  const quantComponents: (VegaColumnType | undefined)[][] = [
+    [undefined, 'quantitative'],
+    ['nominal', 'quantitative'],
+    ['quantitative', 'quantitative'],
+  ];
+
   switch (mark) {
+    case 'bar':
+      return ![
+        [undefined, undefined],
+        ['quantitative', undefined],
+      ].some((c) => isAxisCombination(c as VegaColumnType[]));
+    case 'point':
+      return ![
+        [undefined, undefined],
+        ['nominal', undefined],
+      ].some((c) => isAxisCombination(c as VegaColumnType[]));
     case 'line':
       return isAxisCombination(['quantitative', 'quantitative']);
-    case 'errorband':
-      return isAxisCombination(['ordinal', 'quantitative']);
-    case 'errorbar':
-      return isAxisCombination(['quantitative', 'nominal']);
     case 'tick':
-      return (
-        isAxisCombination([undefined, 'quantitative']) ||
-        isAxisCombination(['nominal', 'quantitative'])
-      );
+      return quantComponents.some(isAxisCombination);
     case 'boxplot':
-      return (
-        isAxisCombination(['quantitative', undefined]) ||
-        isAxisCombination(['quantitative', 'nominal'])
-      );
+      return quantComponents.some(isAxisCombination);
+    case 'errorband':
+      return quantComponents.some(isAxisCombination);
+    case 'errorbar':
+      return quantComponents.some(isAxisCombination);
 
     default:
       return true;

--- a/src/components/Sidebar/Tabs/EditTab.tsx
+++ b/src/components/Sidebar/Tabs/EditTab.tsx
@@ -13,6 +13,8 @@ import {
   VegaEncoding,
   vegaMarkEncodingMap,
   BifrostVegaMark,
+  VegaMark,
+  VegaColumnType,
 } from '../../../modules/VegaEncodings';
 import useSpecHistory from '../../../hooks/useSpecHistory';
 import Pill from '../../ui-widgets/Pill';
@@ -31,12 +33,13 @@ import { hasDuplicateField } from '../../../modules/utils';
 import GraphPill from '../../ui-widgets/GraphPill';
 import { useRef } from 'react';
 import { chartIcons } from '../../../assets/icons/chartIcons/ChartIcons';
-import theme from '../../../theme';
 import AddPillScreen from './AddPillScreen';
 import Slider from '../../ui-widgets/Slider';
+import { BifrostTheme } from '../../../theme';
+import Tooltip from '../../Tooltip';
 
 //TODO: have only scatter
-const variableTabCss = css`
+const variableTabCss = (t: BifrostTheme) => css`
   position: relative;
   width: 100%;
   overflow: scroll;
@@ -60,10 +63,19 @@ const variableTabCss = css`
     justify-content: space-between;
     padding: 0;
 
-    li {
+    button {
       padding: 5px;
-      border-radius: 25%;
-      cursor: pointer;
+      padding-top: 7px;
+      border-radius: 5px;
+      background: transparent;
+
+      &:disabled {
+        opacity: 0.4;
+      }
+
+      &.active {
+        background: ${t.color.primary.standard};
+      }
     }
   }
 
@@ -475,21 +487,23 @@ export default function EditTab({
           {dataSectionOpen ? (
             <section>
               <ul className="mark-list">
-                {chartIcons.map(({ icon: Icon, mark }) => (
-                  <li
-                    key={mark}
-                    onClick={() => handleClickOnMark(mark)}
-                    style={
-                      mark === graphMark
-                        ? {
-                            backgroundColor: `${theme.color.primary.dark}`,
-                          }
-                        : {}
-                    }
-                  >
-                    {mark === graphMark ? <Icon color={'white'} /> : <Icon />}
-                  </li>
-                ))}
+                {chartIcons.map(({ icon: Icon, mark }) => {
+                  return (
+                    <li key={mark}>
+                      <Tooltip message={mark} position="top">
+                        <button
+                          className={mark === graphMark ? 'active' : ''}
+                          onClick={() => handleClickOnMark(mark)}
+                          disabled={!validateMarkChange(mark, graphSpec)}
+                        >
+                          <Icon
+                            color={mark === graphMark ? 'white' : undefined}
+                          />
+                        </button>
+                      </Tooltip>
+                    </li>
+                  );
+                })}
               </ul>
               <ul className="encoding-list">{encodingList}</ul>
               {activeOptions.menu === 'encoding' && (
@@ -658,4 +672,48 @@ function extractPillProps(spec: GraphSpec) {
     }
   });
   return Object.values(pillsByField).flat();
+}
+
+/**
+ * Determines whether a given mark is applicable to a GraphSpec.
+ * @param mark The new mark option to be validated.
+ * @param spec Spec receiving the new mark
+ * @returns true if the mark is valid.
+ */
+function validateMarkChange(mark: VegaMark, spec: GraphSpec): boolean {
+  const xAxisType = spec.encoding['x']?.type;
+  const yAxisType = spec.encoding['y']?.type;
+
+  const isAxisCombination = (types: (VegaColumnType | undefined)[]) => {
+    if (types.length > 1) {
+      return (
+        (types[0] === xAxisType && types[1] === yAxisType) ||
+        (types[1] === xAxisType && types[0] === yAxisType)
+      );
+    } else if (types.length === 1) {
+      return xAxisType === types[0] || yAxisType === types[0];
+    } else return false;
+  };
+
+  switch (mark) {
+    case 'line':
+      return isAxisCombination(['quantitative', 'quantitative']);
+    case 'errorband':
+      return isAxisCombination(['ordinal', 'quantitative']);
+    case 'errorbar':
+      return isAxisCombination(['quantitative', 'nominal']);
+    case 'tick':
+      return (
+        isAxisCombination([undefined, 'quantitative']) ||
+        isAxisCombination(['nominal', 'quantitative'])
+      );
+    case 'boxplot':
+      return (
+        isAxisCombination(['quantitative', undefined]) ||
+        isAxisCombination(['quantitative', 'nominal'])
+      );
+
+    default:
+      return true;
+  }
 }

--- a/src/components/Sidebar/Tabs/EditTab.tsx
+++ b/src/components/Sidebar/Tabs/EditTab.tsx
@@ -74,7 +74,7 @@ const variableTabCss = (t: BifrostTheme) => css`
       }
 
       &.active {
-        background: ${t.color.primary.standard};
+        background: ${t.color.primary.dark};
       }
     }
   }

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -135,7 +135,7 @@ export const vegaChartList = [
   // 'text',
   'tick',
   'trail',
-];
+] as const;
 
 export const vegaCategoricalChartList = [
   'bar',


### PR DESCRIPTION
## Changes
- Mark icons will be disabled for certain axis combinations
- Added tooltips to mark icons
- Global disabled state for buttons
- Tightened the type restrictions on the Vega mark icons.


## Future work / Question
If the user switches the field type or the field itself to something incompatible with the mark type, should we:
- force them to change the mark type (nearest valid mark type)
- Not allow them to change the field
- Let them do it and trust the user
There are certain workflows that might require some inconsistent states, so disallowing the user might be a bad UX. For example, briefly plotting quantitative vs quantitative on a box plot before binning.

The current implementation doesn't take the following into account:
- Aggregations
- Binning