### PR TITLE
Fixed issue with adding encodings or mark to chart object

### DIFF
--- a/jupyter_bifrost/bifrost.py
+++ b/jupyter_bifrost/bifrost.py
@@ -21,7 +21,7 @@ from IPython import get_ipython
 TODO: Add module docstring
 """
 from ipywidgets import DOMWidget, register
-from traitlets import Unicode, List, Int, Dict
+from traitlets import Unicode, List, Int, Dict, Set
 from ._frontend import module_name, module_version
 import json
 
@@ -44,7 +44,8 @@ class BifrostWidget(DOMWidget):
     current_dataframe_index = Int(0).tag(sync=True)
     query_spec = Dict({}).tag(sync=True)
     graph_spec = Dict({}).tag(sync=True)
-    plot_function_args = Dict({}).tag(sync=True)
+    passed_encodings = Dict({}).tag(sync=True)
+    passed_kind = Unicode("").tag(sync=True)
     graph_data = List([]).tag(sync=True)
     graph_bounds = Dict({}).tag(sync=True)
     graph_encodings = Dict({}).tag(sync=True)
@@ -54,13 +55,11 @@ class BifrostWidget(DOMWidget):
     df_code = Unicode("").tag(sync=True)
     df_columns = List([]).tag(sync=True)
     selected_columns = List([]).tag(sync=True)
-    selected_mark = Unicode("").tag(sync=True)
     selected_data = List([]).tag(sync=True)
     suggested_graphs = List([]).tag(sync=True)
     column_types = Dict({}).tag(sync=True)
     column_name_map = Dict({}).tag(sync=True)
     graph_data_config = Dict({"sampleSize": 100, "datasetLength": 0}).tag(sync=True)
-
 
     def __init__(
         self,
@@ -81,16 +80,26 @@ class BifrostWidget(DOMWidget):
             df, data, column_types, kind=kind, x=x, y=y, color=color
         )
         df.columns = column_name_map.values()
-
         self.set_trait("df_columns", sorted(list(df.columns)))
         self.set_trait("selected_data", [])
         self.set_trait("query_spec", graph_info["query_spec"])
         self.set_trait("graph_data", graph_info["data"])
         self.set_trait("graph_spec", graph_info["graph_spec"])
-        self.set_trait("plot_function_args", graph_info["args"])
+        self.set_trait("passed_encodings", graph_info["selected_encodings"])
+        self.set_trait(
+            "selected_columns",
+            [
+                encoding
+                for encoding in graph_info["selected_encodings"].values()
+                if encoding
+            ],
+        ),
+        self.set_trait("passed_kind", graph_info["passed_kind"])
         self.set_trait("column_types", column_types)
         self.set_trait("column_name_map", column_name_map)
-        self.set_trait("graph_data_config", {"sampleSize": 100, "datasetLength": len(df)})
+        self.set_trait(
+            "graph_data_config", {"sampleSize": 100, "datasetLength": len(df)}
+        )
         if df_watcher.plot_output:
             self.set_trait("output_variable", df_watcher.plot_output)
         if df_watcher.bifrost_input:
@@ -107,18 +116,17 @@ class BifrostWidget(DOMWidget):
         if self.output_variable != "":
             get_ipython().run_cell(code).result
 
-
     @observe("graph_data_config")
     def update_dataset(self, changes):
         config = changes["new"]
         df_len = len(self.df_history[-1])
         if changes["old"]["sampleSize"] >= df_len and config["sampleSize"] >= df_len:
             return
-        self.set_trait("graph_data", self.get_data(self.df_history[-1], config["sampleSize"]))
-            
+        self.set_trait(
+            "graph_data", self.get_data(self.df_history[-1], config["sampleSize"])
+        )
 
-
-    def get_data(self, df: pd.DataFrame, sampleLimit:int=None):
+    def get_data(self, df: pd.DataFrame, sampleLimit: int = None):
         if sampleLimit:
             df = df.sample(n=sampleLimit)
         return json.loads(df.to_json(orient="records"))
@@ -198,5 +206,6 @@ class BifrostWidget(DOMWidget):
             "data": data,
             "query_spec": {"spec": query_spec},
             "graph_spec": graph_spec,
-            "args": {"x": x, "y": y, "color": color, "kind": kind},
+            "selected_encodings": {"x": x, "y": y, "color": color},
+            "passed_kind": kind if kind else "",
         }

--- a/jupyter_bifrost/bifrost_api.py
+++ b/jupyter_bifrost/bifrost_api.py
@@ -2,7 +2,6 @@ import os, sys
 import typing
 import pandas as pd
 from .bifrost import BifrostWidget
-import IPython
 from IPython.core.display import display
 
 
@@ -81,6 +80,7 @@ class Chart:
         except AttributeError as e:
             print(e)
             sys.exit(1)
+
         self.encoding["x"] = x
         self.encoding["y"] = y
         self.encoding["color"] = color
@@ -91,7 +91,6 @@ class Chart:
             return None
         return s.replace(" ", "_").replace("(", "").replace(")", "")
 
-    # TODO: reequire plot call
     def plot(self) -> pd.DataFrame:
         formatted_x, formatted_y, formatted_color = [
             self.format_string(self.encoding[key]) for key in self.encoding
@@ -114,4 +113,7 @@ class Chart:
             formatted_color,
         )
         display(w)
+        # reset
+        self.mark = None
+        self.encoding = {"x": None, "y": None, "color": None}
         return w.df_history[-1]

--- a/src/components/BifrostReactWidget.tsx
+++ b/src/components/BifrostReactWidget.tsx
@@ -96,10 +96,10 @@ export default function BifrostReactWidget(props: BifrostReactWidgetProps) {
 }
 
 function BifrostReactWidgetDisplay() {
-  const plotArgs = useModelState('plot_function_args')[0];
-  // TODO: Might need to check the mark as well
+  const plotArgs = useModelState('passed_encodings')[0];
+  const kind = useModelState('passed_kind')[0];
   const [onboarded, setOnboarded] = useState(
-    Boolean(plotArgs['x'] && plotArgs['y'])
+    Boolean(plotArgs['x'] && plotArgs['y'] && kind)
   );
 
   useEffect(() => {

--- a/src/components/Onboarding/ColumnSelectorSidebar.tsx
+++ b/src/components/Onboarding/ColumnSelectorSidebar.tsx
@@ -135,14 +135,6 @@ export default function ColumnSelectorSidebar(props: { plotArgs: Args }) {
     [props.plotArgs]
   );
 
-  // Ensure that pre-selected columns are included on initial render.
-  useEffect(() => {
-    if (selectedColumns.length) {
-      return;
-    }
-    setSelectedColumns(Array.from(preSelectedColumns));
-  }, []);
-
   // Create charts whenever the column selection changes
   useEffect(recommendCharts, [selectedColumns]);
 
@@ -150,7 +142,7 @@ export default function ColumnSelectorSidebar(props: { plotArgs: Args }) {
     const dataSchema = data2schema(data);
     const dataAsp = schema2asp(dataSchema);
 
-    const selectedEncodings = Array.from(selectedColumns).map((column) => {
+    const selectedEncodings = selectedColumns.map((column) => {
       if (preSelectedColumns.has(column)) {
         return spec.spec.encodings.filter(
           (encoding: any) => encoding['field'] === column
@@ -260,7 +252,7 @@ export default function ColumnSelectorSidebar(props: { plotArgs: Args }) {
         </fieldset>
       </form>
       <ul className="column-tags">
-        {Array.from(selectedColumns).map((column: string, i) => {
+        {selectedColumns.map((column: string, i) => {
           return (
             <Pill key={column} style={{ margin: 4, padding: 4 }}>
               <div className="tag-content-wrapper">

--- a/src/hooks/bifrost-model.ts
+++ b/src/hooks/bifrost-model.ts
@@ -62,7 +62,6 @@ export type Args = {
   x: string;
   y: string;
   color: string;
-  kind: string;
 };
 
 export type SelectionData = [

--- a/src/modules/VegaEncodings.ts
+++ b/src/modules/VegaEncodings.ts
@@ -119,22 +119,22 @@ export const vegaParamPredicatesList = [
 
 export const vegaChartList = [
   // 'arc',
-  'area',
+  // 'area',
   'bar',
   'boxplot',
-  'circle',
+  // 'circle',
   'errorband',
   'errorbar',
   // 'geoshape',
   // 'image',
   'line',
   'point',
-  'rect',
+  // 'rect',
   // 'rule',
-  'square',
+  // 'square',
   // 'text',
   'tick',
-  'trail',
+  // 'trail',
 ];
 
 export const vegaCategoricalChartList = [

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -24,6 +24,7 @@ import { MODULE_NAME, MODULE_VERSION } from './version';
 
 // Import the CSS
 import '../css/widget.css';
+import { VegaMark } from './modules/VegaEncodings';
 
 const bifrostModelPropDefaults = {
   spec_history: [] as GraphSpec[],
@@ -36,12 +37,12 @@ const bifrostModelPropDefaults = {
   df_columns: [] as string[],
   selected_data: ['', {}] as SelectionData,
   selected_columns: [] as string[],
-  selected_mark: '',
+  passed_kind: '' as VegaMark | '',
   graph_data: {} as GraphData,
   graph_bounds: {} as SelectionData[1],
   suggested_graphs: [] as SuggestedGraphs,
   flags: {},
-  plot_function_args: {} as Args,
+  passed_encodings: {} as Args,
   column_types: {} as Record<EncodingInfo['field'], EncodingInfo['type']>,
   column_name_map: {} as Record<string, string>,
   graph_data_config: { sampleSize: 100, datasetLength: 1 } as GraphDataConfig,


### PR DESCRIPTION
## Change
* Fixed the issue with adding marks or encodings to the chart object using `encode()` or `mark_{mark_type}`
* Unlike Altair, Bifrost doesn't store the initial encodings. Every time `plot()` gets called, it doesn't save the encodings and mark being used.
    * Altair stores the initial encodings. So, when you first give x, y, color, and mark and later give x and y, it still uses color and mark previously given in addition to the new x and y.
    * Bifrost gets reset every time `plot()` is called. It doesn't use any of the previously given encodings or mark because it provides users options to choose encoding and mark with Draco recommendation system when they are not given.