### PR TITLE
GraphPill Padding and Aggregation Bug

### DIFF
--- a/src/components/ui-widgets/GraphPill.tsx
+++ b/src/components/ui-widgets/GraphPill.tsx
@@ -72,6 +72,7 @@ export default function GraphPill(props: GraphPillProps) {
         white-space: nowrap;
         cursor: pointer;
         width: 100%;
+        margin: auto 4px;
         text-align: center;
 
         &:hover {
@@ -82,6 +83,7 @@ export default function GraphPill(props: GraphPillProps) {
       button {
         width: 100%;
         text-align: center;
+        margin: auto 4px;
       }
     }
 

--- a/src/modules/VegaPandasTranslator.ts
+++ b/src/modules/VegaPandasTranslator.ts
@@ -4,6 +4,7 @@ import {
   VegaAggregation,
 } from './VegaEncodings';
 import { GraphSpec, EncodingInfo } from '../hooks/bifrost-model';
+import { isFunction } from './utils';
 
 const filterTypes = new Set<string>(vegaParamPredicatesList);
 
@@ -109,11 +110,13 @@ export default class VegaPandasTranslator {
             pandasGroupFields,
             `${dfName} = ${dfName}.join(${dfName}.groupby(group_fields).agg("${agg}")["${encoding.field}"], on=group_fields, rsuffix=" ${agg}")`,
           ].join('\n');
-        } else {
+        } else if (isFunction(agg)) {
           return [
             pandasGroupFields,
             `${dfName} = ${agg(encoding, dfName)}`,
           ].join('\n');
+        } else {
+          return '';
         }
       })
       .join('\n');


### PR DESCRIPTION
SMALL FIX: added padding between pill header elements to prevent elements from slamming together in long text strings.

**Before**
<img width="220" alt="Screen Shot 2021-08-23 at 4 20 10 PM" src="https://user-images.githubusercontent.com/33008436/130531588-624caa5d-9c94-467c-b857-f86cdf5f998c.png">

**After**
<img width="251" alt="Screen Shot 2021-08-23 at 4 17 33 PM" src="https://user-images.githubusercontent.com/33008436/130531594-2d4ab264-ccc1-4334-b3d1-8f5bacc491fe.png">
